### PR TITLE
Add some font metrics to Font objects

### DIFF
--- a/lib/pdf/reader/font.rb
+++ b/lib/pdf/reader/font.rb
@@ -26,6 +26,8 @@
 class PDF::Reader
   class Font
     attr_accessor :label, :subtype, :encoding, :descendantfonts, :tounicode
+    attr_accessor :widths, :first_char, :ascent, :descent, :missing_width, :bbox
+    
     attr_reader :basefont
 
     # returns a hash that maps glyph names to unicode codepoints. The mapping is based on
@@ -71,6 +73,15 @@ class PDF::Reader
         params.collect { |param| self.to_utf8(param) }
       else
         params
+      end
+    end
+
+    def glyph_width c
+      @missing_width ||= 0
+      if @widths.nil?
+        0
+      else
+        @widths.fetch(c.codepoints.first - @first_char, @missing_width)
       end
     end
   end

--- a/lib/pdf/reader/pages_strategy.rb
+++ b/lib/pdf/reader/pages_strategy.rb
@@ -471,6 +471,17 @@ class PDF::Reader
           stream = @ohash.object(desc[:ToUnicode])
           fonts[label].tounicode = PDF::Reader::CMap.new(stream.unfiltered_data)
         end
+        if desc[:FontDescriptor]
+          fd = resolve_references(desc[:FontDescriptor])
+          fonts[label].ascent = fd[:Ascent] if fd[:Ascent]
+          fonts[label].descent = fd[:Descent] if fd[:Descent]
+          fonts[label].missing_width = fd[:MissingWidth] if fd[:MissingWidth]
+          fonts[label].bbox = resolve_references(fd[:FontBBox]) if fd[:FontBBox]
+        end
+        if desc[:Widths] and desc[:FirstChar]
+          fonts[label].widths = resolve_references(desc[:Widths])
+          fonts[label].first_char = desc[:FirstChar]
+        end
       end
       fonts
     end
@@ -481,3 +492,4 @@ class PDF::Reader
   ################################################################################
 end
 ################################################################################
+


### PR DESCRIPTION
Pages strategy adds glyph widths, ascent, descent and missing char
width, if available, to Font objects.

Useful when determining potential width and height of runs of text (and in constructing runs of text).
