### PR TITLE
Add RunLengthDecode filter support

### DIFF
--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -73,4 +73,10 @@ describe PDF::Reader::Filter do
     filter.filter(encoded_data).should eql("Rubp")
   end
 
+  it "should filter a RunLengthDecode stream correctly" do
+    filter = PDF::Reader::Filter.new(:RunLengthDecode)
+    encoded_data = [2, "\x00"*3, 255, "\x01", 128].pack('Ca*Ca*C')
+    filter.filter(encoded_data).should eql("\x00\x00\x00\x01\x01")
+  end
+
 end


### PR DESCRIPTION
For extracting PPM data from PDFs, RunLengthDecode filter support is required. This adds support for that filter.

It also changes how the supported filters are stored, so that it should be much easier for a user to add support for an additional filter, by doing something like:

``` ruby
module OtherFilterSupport

  def otherfilter(data)
  end

  PDF::Reader::Filter.filters[:OtherFilter] = :otherfilter
  PDF::Reader::Filter.include self
end
```
