### PR TITLE
Update README.rdoc to stop people trying to follow the new examples with the old version.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,10 +1,17 @@
-= PLEASE NOTE!
+= !PLEASE NOTE!
 
 All the examples below are for the latest (pre-release) version of the gem (0.11)
 
-If you have installed the gem via the 'gem install pdf-reader' command the 
-examples below *will not work* for you. Please check the examples that come with 
-previous version of the gem (0.10).
+If you have installed the gem via the rubygems with the command:
+
+    $ gem install pdf-reader
+
+Then the examples below *will not work* for you. Please check the examples that 
+come with previous version of the gem (0.10).
+
+If you want to install the latest version of this gem use the command:
+
+    $ gem install pdf-reader --prerelease
 
 = Release Notes
 


### PR DESCRIPTION
Added a warning to the top of README.rdoc to point out that the examples contained do not apply to the version installed via RubyGems (0.10). 

I had issues trying to get it to work, only to find out it wasn't the first one to have the problem (there's at least one open issue about this, and I saw the various messages to the google-group).

Thanks for the gem!
