### PR TITLE
Return an empty string when a token is empty

### DIFF
--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -318,7 +318,7 @@ class PDF::Reader
           # opening delimiter, start of new token
           @tokens << tok if tok.size > 0
           @tokens << chr
-          @tokens << " " if chr == "/" && peek_char == " "
+          @tokens << "" if chr == "/" && peek_char == " "
           tok = ""
           break
         when "\x29", "\x5D", "\x7D"

--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -130,10 +130,14 @@ class PDF::Reader
     # reads a PDF name from the buffer and converts it to a Ruby Symbol
     def pdf_name
       tok = @buffer.token
-      tok.gsub!(/#([A-Fa-f0-9]{2})/) do |match|
-        match[1, 2].hex.chr
+      if tok.nil? || tok == ""
+        ""
+      else
+        tok.gsub!(/#([A-Fa-f0-9]{2})/) do |match|
+          match[1, 2].hex.chr
+        end
+        tok.to_sym
       end
-      tok.to_sym
     end
     ################################################################################
     # reads a PDF array from the buffer and converts it to a Ruby Array.

--- a/spec/buffer_spec.rb
+++ b/spec/buffer_spec.rb
@@ -86,7 +86,7 @@ describe PDF::Reader::Buffer, "token method" do
     buf.token.should eql("/")
     buf.token.should eql("V")
     buf.token.should eql("/")
-    buf.token.should eql(" ")
+    buf.token.should eql("")
     buf.token.should eql(">>")
     buf.token.should be_nil
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -21,9 +21,9 @@ describe PDF::Reader::Parser do
 
   # '/' is a valid PDF name, but :"" is not a valid ruby symbol.
   # How should I handle this?
-  it "should parse an empty name correctly" #do
-    #parse_string("/").parse_token.should eql(:"")
-  #end
+  it "should parse an empty name correctly" do
+    parse_string("/").parse_token.should eql("")
+  end
 
   it "should parse booleans correctly" do
     parse_string("true").parse_token.should be_true


### PR DESCRIPTION
All specs are passing and I went with the behavior of a similar spec:

<code>parse_string("()").parse_token.should eql("")</code>

I decided not to go with the empty symbol route because of the different values that would be returned based on the version of Ruby you are running.

If you were to return :" " in 1.8 and :"" in 1.9 then :" ".to_s.empty? in 1.8 would be false and :"".empty? in 1.9 would be true. So you'd have different behavior across Rubies.
