### PR TITLE
Properly tokenize "/\n" as an empty PDF name

### DIFF
--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -331,7 +331,7 @@ class PDF::Reader
           @tokens << tok if tok.size > 0
           @tokens << chr
           next_char = peek_char
-          @tokens << "" if chr == "/" && (next_char == " " || next_char.nil?)
+          @tokens << "" if chr == "/" && [nil, " ", "\n"].include?(next_char)
           tok = ""
           break
         else

--- a/spec/buffer_spec.rb
+++ b/spec/buffer_spec.rb
@@ -97,6 +97,13 @@ describe PDF::Reader::Buffer, "token method" do
     buf.token.should eql("/")
     buf.token.should eql("")
     buf.token.should be_nil
+
+    buf = parse_string("/\n/")
+    buf.token.should eql("/")
+    buf.token.should eql("")
+    buf.token.should eql("/")
+    buf.token.should eql("")
+    buf.token.should be_nil
   end
 
   it "should tokenise a dict correctly" do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -26,6 +26,9 @@ describe PDF::Reader::Parser do
   if RUBY_VERSION >= "1.9"
     it "should parse an empty name correctly" do
       parse_string("/").parse_token.should eql("".to_sym)
+      parser = parse_string("/\n/")
+      parser.parse_token.should eql("".to_sym)
+      parser.parse_token.should eql("".to_sym)
     end
 
     it "should parse two empty names correctly" do
@@ -36,6 +39,9 @@ describe PDF::Reader::Parser do
   else
     it "should parse an empty name correctly" do
       parse_string("/").parse_token.should eql(:" ")
+      parser = parse_string("/\n/")
+      parser.parse_token.should eql(:" ")
+      parser.parse_token.should eql(:" ")
     end
 
     it "should parse two empty names correctly" do


### PR DESCRIPTION
Per PDF 32000-1:2008 sec 7.3.5, whitespace in a PDF name must always be
escaped hexadecimally, and no whitespace may come between the / and the
start of the name. So a name starting "/\n" should always be tokenized
as an empty name.
