### PR TITLE
Add spec and fix issue for extra token whitespace during token parsing

### DIFF
--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -36,6 +36,7 @@ class PDF::Reader
   # the raw tokens into objects we can work with (strings, ints, arrays, etc)
   #
   class Buffer
+    TOKEN_WHITESPACE=["\x00", "\x09", "\x0A", "\x0C", "\x0D", "\x20"]
 
     attr_reader :pos
 
@@ -299,9 +300,14 @@ class PDF::Reader
             chr = @io.read(1)
             done = true if chr.nil? || chr == "\x0A" || chr == "\x0D"
           end
-        when "\x00", "\x09", "\x0A", "\x0C", "\x0D", "\x20"
+        when *TOKEN_WHITESPACE
           # white space, token finished
           @tokens << tok if tok.size > 0
+
+          #If the token was empty, chomp the rest of the whitespace too
+          while TOKEN_WHITESPACE.include?(peek_char) && tok.size == 0
+            @io.read(1)
+          end
           tok = ""
           break
         when "\x3C"

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -154,6 +154,12 @@ describe PDF::Reader::Parser do
     dict[:Supplement].should  eql(5)
   end
 
+  it "should parse dictionary with extra space ok" do
+    str = "<<\r\n/Type /Pages\r\n/Count 3\r\n/Kids [ 25 0 R 27 0 R]\r\n                                                      \r\n>>"
+    dict = parse_string(str).parse_token
+    dict.size.should == 3
+  end
+
   it "should parse an array correctly" do
     parse_string("[ 10 0 R 12 0 R ]").parse_token.size.should eql(2)
   end


### PR DESCRIPTION
I ran across a PDF that had extra token whitespace that went well beyond what the parse_tokens was handling.  I would have forwarded the PDF, but it has some PII in that makes that impossible.  In any case the spec test I added for the parser was the exact dictionary entry that came from the PDF that was throwing a Malformed exception.  It now parses the original PDF fine with these changes.

Let me know if you'd like me to tidy up this code some before you merge it.  Be happy to help anyway I can.
