### PR TITLE
Fix to prevent some lines being read out of order

### DIFF
--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -48,6 +48,11 @@ module PDF
       def show_text(string) # Tj
         raise PDF::Reader::MalformedPDFError, "current font is invalid" if @state.current_font.nil?
         newx, newy = @state.trm_transform(0,0)
+        
+        # make sure slight variations in Y-coord don't 
+        # cause lines to read out-of-order
+        newy = newy.round(0)
+        
         @content[newy] ||= ""
         @content[newy] << @state.current_font.to_utf8(string)
       end


### PR DESCRIPTION
In response to issue#50 - temporary fix to prevent lines or blocks of text from being read out of order.
