### PR TITLE
make ignoring a junk prefix 1.8.7 compatible

### DIFF
--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -355,7 +355,7 @@ class PDF::Reader
     def pdf_offset(stream)
       stream.rewind
       ofs = stream.pos
-      until stream.readchar == '%' || ofs > 50
+      until (c = stream.readchar) == '%' || c == 37 || ofs > 50
         ofs += 1
       end
       ofs < 50 ? ofs : nil


### PR DESCRIPTION
James, I think this should fixup the 1.8.7 spec failures
- see original 1.9 fix #54
