### PR TITLE
Cache parsed glyph list for performance

### DIFF
--- a/lib/pdf/reader/glyph_hash.rb
+++ b/lib/pdf/reader/glyph_hash.rb
@@ -26,6 +26,7 @@
 class PDF::Reader
   class GlyphHash # :nodoc:
     def initialize
+      # only parse the glyph list once, and cache the results (for performance)
       @adobe = @@cache ||= load_adobe_glyph_mapping
     end
 


### PR DESCRIPTION
I'm just working on a patch for Prawn which greatly speeds up running the spec tests, and I found that line 80 of glyph_hash.rb from pdf-reader is a hotspot, presumably because many GlyphHash objects are used, and each time a new one is created, it parses the whole glyph list all over again. When running the Prawn specs with JRuby, just that line generates ~1.1GB of garbage. I don't know if MRI's regexp engine allocates so much memory, but in any case, I have observed that this change speeds up the Prawn specs quite a bit when running under MRI.

Presumably other uses of pdf-reader will also benefit from this patch. Although it uses a class variable with no synchronization or anything, thread safety shouldn't be compromised.
