### PR TITLE
Requested profiling scripts

### DIFF
--- a/tools/bench.rb
+++ b/tools/bench.rb
@@ -1,23 +1,70 @@
 # coding: utf-8
 
-# a quick script for profiling performance with perftools.
-#
-# USAGE
-#
-#     ruby tools/bench.rb
-#     evince bench.pdf
+# a script for measuring text extraction performance
 
-$:.unshift "../lib"
-require 'pdf-reader'
-require 'perftools'
+# TO BENCHMARK: ruby tools/bench.rb <runs>
+# TO PROFILE:   ruby tools/bench.rb perftools
+#         OR:   ruby-prof tools/bench.rb <runs>
+# FOR OBJECT ALLOCATION STATS: ruby tools/bench.rb memprof
+# TO COUNT GC RUNS: ruby tools/bench.rb gc
 
-PerfTools::CpuProfiler.start("/tmp/restart_profile") do
-  PDF::Reader.open("restart.pdf") do |reader|
+$project_root = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+require 'rubygems' # for Ruby 1.8
+$:.unshift "#{$project_root}/lib"
+require 'pdf/reader'
+
+# Extract all the text from a large PDF
+
+def extract_text
+  PDF::Reader.open("#{$project_root}/spec/data/no_text_spaces.pdf") do |reader|
     reader.pages.each do |page|
       page.text
     end
   end
 end
 
-`pprof.rb --text /tmp/restart_profile > bench.txt`
-`pprof.rb --pdf  /tmp/restart_profile > bench.pdf`
+case ARGV[0]
+when "memprof"
+  # Measure object allocation with memprof
+  require 'memprof'
+  GC.disable
+  Memprof.track { extract_text }
+
+when "perftools"
+  # Profile with perftools.rb
+  # (The best thing about perftools.rb is that it shows you time spent on
+  #   garbage collection)
+  require 'perftools'
+  PerfTools::CpuProfiler.start("/tmp/perftools_data") do
+    extract_text
+  end
+  `pprof.rb --text /tmp/perftools_data > #{$project_root}/tools/profiles/perftools.txt`
+  `pprof.rb --pdf /tmp/perftools_data > #{$project_root}/tools/profiles/perftools.pdf`
+
+when "gc"
+  before = GC.count
+  extract_text
+  puts "GC ran #{GC.count - before} times"  
+
+else
+  # Benchmark
+  # Average the results over multiple runs
+  # Throw out the best and worst results, and average what remains
+  # With 10 runs, the results seem to fluctuate by as much as 6-7%
+  # I'd like that to be 1-2%, but that requires a VERY high number of runs
+
+  runs  = (ARGV[0] || 10).to_i
+  times = []
+
+  runs.times do
+    start = Time.new
+    extract_text
+    times << (Time.new - start)
+    sleep(0.1) # results seem more consistent this way
+  end
+
+  times.sort!
+  times = times.drop(runs / 5).take(runs - (runs * 2 / 3))
+  average = times.reduce(0,&:+).to_f / times.size
+  puts "#{"%0.3f" % average} seconds"
+end

--- a/tools/profile.rb
+++ b/tools/profile.rb
@@ -1,0 +1,20 @@
+# Driver to run a bunch of profiling scripts in parallel,
+#   leaving all the results in tools/profiles
+# Assumes "ruby" is Ruby 1.9, and "ruby1.8" is Ruby 1.8.7
+# Also assumes that all needed gems are installed
+# This script itself should be run under Ruby 1.9
+
+require 'fileutils'
+
+project_root = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+dir = "#{project_root}/tools/profiles"
+FileUtils.mkdir(dir) unless File.exist?(dir)
+
+pids = []
+pids << fork { `ruby-prof #{project_root}/tools/bench.rb 1 --file=#{dir}/rubyprof.txt` }
+pids << fork { `ruby-prof #{project_root}/tools/bench.rb 1 --file=#{dir}/rubyprof-graph.htm --printer=graph_html` }
+pids << fork { `ruby-prof #{project_root}/tools/bench.rb 1 --file=#{dir}/rubyprof-stack.htm --printer=call_stack` }
+pids << fork { `ruby1.8 #{project_root}/tools/bench.rb memprof > #{dir}/memprof.txt` }
+pids << fork { `ruby #{project_root}/tools/bench.rb perftools` }
+
+pids.each { |pid| Process.wait(pid) }


### PR DESCRIPTION
James, I've been busy lately, but I just took some time to write some scripts for profiling pdf-reader. You will need to have "ruby-prof" and "memprof" installed under Ruby 1.8, and "perftools.rb" installed under Ruby 1.9. (Perhaps add to the Gemfile?) The "ruby-prof" binstub must be on your system path. ("ruby-prof -v" to check.)

The key script is tools/bench.rb, which can be used for benchmarking, CPU profiling, or memory-allocation profiling (with different command-line args). Have a look, I think it should be self-explanatory.

Then there is tools/profile.rb, which automates the process of calling tools/bench.rb to get various types of profiles, and saves them all in tools/profiles. After you run that you should have...
- rubyprof.txt, perftools.txt: flat text files generated by ruby-prof and perftools (respectively), which identify the methods with the highest "self" time. (Time spent in the body of the method itself, rather than in its callees.) This is usually a good place to start when looking for bottlenecks.
- perftools.pdf: a PDF graph from perftools, showing hot methods and paths through the code. GOOD: it shows the amount of time spent in the garbage collector. BAD: unless the benchmark runs for long enough, it may not collect enough samples to provide reliable results.
- memprof.txt: this will identify how many objects were allocated by the benchmark, and where. Decreasing those numbers can squeeze down the time spent in the GC.
- rubyprof-graph.htm: This also organizes the methods by "self time", but it identifies which methods call into each "hot" method, and how many times. It is hyperlinked so you can click around find out who is calling the callers, etc.
- rubyprof-stack.htm: Open this up and you'll get the concept right away. You can see all the code paths, from the top-level entry method right on down, and how much time was spent in each of those paths.

If the "GC" time which you see in perftools.txt or perftools.pdf seems high, use memprof.txt to find out where memory is being allocated (and stop it). To attack the time spent in computation itself:

Finding out the methods with the highest "self time" is a good first step. It's the fastest way to identify CPU bottlenecks. But you'll also want to examine the "call stack" display of times in rubyprof-stack.htm, as well as rubyprof-graph.htm. These different ways of displaying information will help you find different bottlenecks. 

For example, you might have a mid-level method which calls a bunch of lower level methods, which in turn call a bunch more lower level methods, etc. All together, they are taking a lot of time. But you won't see it in the "self time" display, because that time is spread out over a bunch of methods. However, in the "call stack" display, it will come out clearly.

Another problem with the "self time" display is when you are spending a lot of time on things like `Array#map`, `Fixnum#*`, and so on. If you see very general core methods like that high in the "self time" display, go to rubyprof-graph.htm to find out where they are being called from (and pay special attention to the _number_ of calls from each call site). If you find that the calls are coming from other "general" core methods, then you may have to resort to searching in the "call stack" display to find the problem site.

On the other hand, when you have a low-level method which is inefficient, and it's used _all over_ the codebase, rather than being called many times from one specific place, it may not come out clearly in the "call stack" display. In that case, the "self time" display will show the problem more clearly.

When you find a certain method is consuming a lot of time, _always_ pay attention to the _number of times_ it is being called. In some cases, the problem is not that the method is slow, but that it is called too many times. This may point to some O(n^2) behavior somewhere, or the need for caching. Even if the solution is to optimize the method, knowing how many times it is being used can help you understand what kind of optimizations will be effective. When the number of calls is _very, very_ high, that's when you temporarily put good coding style aside and do really detailed, low-level optimizations like manually inlining methods.

One thing which I have identified might be helpful, though I don't have the time to do it now, is to use symbols rather than strings for tokens like "(", "[", and so on. It will require using something else for PDF names (because otherwise the name ">>" would be indistinguishable from an "end-of-dictionary" token).

Note also that the code is getting fast enough that a more intensive benchmark may be needed. I'm using spec/data/no_text_spaces.pdf, but perhaps you have a really big, slow PDF which would be better for benchmarking.
