### PR TITLE
Only require LRUHash instead of the whole of Hashery

### DIFF
--- a/lib/pdf/reader/object_cache.rb
+++ b/lib/pdf/reader/object_cache.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-require 'hashery'
+require 'hashery/lru_hash'
 
 class PDF::Reader
 


### PR DESCRIPTION
We are having an issue with PDF-reader causing issues with Prawn and a couple of other gems we use due to Hashery being included outright. Instead of including the entire contents of hashery, we only need to include Hashery/LRUHash as no other class/module is used in ObjectCache.

Monkey patching ruby core is bad.
