### PR TITLE
Corrected PDF::Reader#page_count spec description for no_text_spaces

### DIFF
--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -33,7 +33,7 @@ describe PDF::Reader do
       end
     end
 
-    context "with cairo-basic" do
+    context "with no_text_spaces" do
       it "should return the correct page_count" do
         PDF::Reader.new(no_text_spaces).page_count.should eql(6)
       end


### PR DESCRIPTION
I'm was reading through the specs and this description didn't match the test, so I'm just correcting it.
