### PR TITLE
Update extract_fonts.rb

### DIFF
--- a/examples/extract_fonts.rb
+++ b/examples/extract_fonts.rb
@@ -17,8 +17,8 @@ module ExtractFonts
       return count if page.fonts.nil? || page.fonts.empty?
 
       page.fonts.each do |label, font|
-        next if complete_refs[font]
-        complete_refs[font] = true
+        next if complete_refs[label]
+        complete_refs[label] = true
 
         process_font(page, font)
 


### PR DESCRIPTION
In order to retain in complete_refs the fonts already processed. The key of the hash has to be the label, not the font.
