### PR TITLE
uses Digest::MD5::hexdigest instead of md5sum for better compatibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ task :integrity_yaml do
     path_without_spec = path.gsub("spec/","")
     data[path_without_spec] = {
       :bytes => File.size(path),
-      :md5 => Digest::MD5.hexdigest(File.read(path))
+      :md5 => Digest::MD5.file(path).hexdigest.encode('UTF-8')
     } if File.file?(path)
   end
   File.open("spec/integrity.yml","wb") { |f| f.write YAML.dump(data)}


### PR DESCRIPTION
Rather than rely on md5sum, I changed a single line to use Ruby's built-in md5 digest method.

On OSX (at least my 2011 MBA), md5sum is not installed. This is required to run `rake integrity_yaml`, which is in turn required to add any PDFs to the test suite.

To ensure that this works, I renamed the `integrity.yml` file to `old_integrity.yml`, re-ran `rake integrity_yaml` and compared md5 checksums of both files (how meta!):

``` sh
$ md5 spec/integrity.yml
MD5 (spec/integrity.yml) = ef93ad82b30e44141a7cd90be1605228
$ md5 spec/old_integrity.yml
MD5 (spec/old_integrity.yml) = ef93ad82b30e44141a7cd90be1605228
```
