### PR TITLE
Fix ArgumentError: Unknown glyph width for 160 Helvetica

### DIFF
--- a/lib/pdf/reader/width_calculator/built_in.rb
+++ b/lib/pdf/reader/width_calculator/built_in.rb
@@ -77,6 +77,8 @@ class PDF::Reader
       def glyph_width(code_point)
         return 0 if code_point.nil? || code_point < 0
 
+        code_point = 32 if code_point == 160
+
         m = @metrics.char_metrics_by_code[code_point]
         if m.nil?
           names = @font.encoding.int_to_name(code_point)

--- a/spec/width_calculator/built_in_spec.rb
+++ b/spec/width_calculator/built_in_spec.rb
@@ -30,3 +30,20 @@ describe PDF::Reader::WidthCalculator::BuiltIn, "#initialize" do
     end
   end
 end
+
+describe PDF::Reader::WidthCalculator::BuiltIn, "#glyph_width" do
+    let!(:encoding)     { PDF::Reader::Encoding.new(:StandardEncoding) }
+    let!(:font)         { double(:basefont => :Helvetica,
+                                 :subtype => :TrueType,
+                                 :encoding => encoding) }
+
+    subject(:width_calculator) {
+      PDF::Reader::WidthCalculator::BuiltIn.new(font)
+    }
+
+    it "should not raise an error for code point 160 (non breaking space)" do
+      lambda {
+        width_calculator.glyph_width(160)
+      }.should_not raise_error
+    end
+end


### PR DESCRIPTION
This PR should fix `ArgumentError: Unknown glyph width for 160 Helvetica` and also should fix issues like #117, #124, and #126.

I think that the problem is that there is no character map for glyph id 160 when calculating glypth width in `PDF::Reader::WidthCalculator::BuiltIn#glyph_width`. According to [this page](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=iws-chapter08#ba57949e):

```
The mapping subtables use various formats to reduce their size, but all formats map from a character code to a glyph id. Multiple character codes can map to the same glyph id. For example, space (U+0020) and no-break space (U+00A0) often map to the same glyph id.
```

So,  using code point to 32 (0x20) for code point 160 should fix `ArgumentError: Unknown glyph width for 160 Helvetica`.


Thank you