### PR TITLE
remove obsolete option for Rspec3

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,5 @@ require 'digest/md5'
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 
 RSpec.configure do |config|
-  config.expect_with :rspec, :stdlib
   config.include ReaderSpecHelper
 end


### PR DESCRIPTION
This change removes an option not recognised anymore by the version 3 of rspec.