### PR TITLE
Fix error fetching page text when all runs are empty

### DIFF
--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -45,6 +45,9 @@ class PDF::Reader
     #
     def interesting_rows(rows)
       line_lengths = rows.map { |l| l.strip.length }
+
+      return [] if line_lengths.all?(&:zero?)
+
       first_line_with_text = line_lengths.index { |l| l > 0 }
       last_line_with_text  = line_lengths.size - line_lengths.reverse.index { |l| l > 0 }
       interesting_line_count = last_line_with_text - first_line_with_text

--- a/spec/page_layout_spec.rb
+++ b/spec/page_layout_spec.rb
@@ -13,6 +13,20 @@ describe PDF::Reader::PageLayout, "#to_s" do
         subject.to_s.should == ""
       end
     end
+
+    context "with only blank word(s)" do
+      let!(:runs) do
+        [
+          PDF::Reader::TextRun.new(30, 700, 50, 12, "")
+        ]
+      end
+      subject { PDF::Reader::PageLayout.new(runs, mediabox)}
+
+      it "should return a correct string" do
+        subject.to_s.should == ""
+      end
+    end
+
     context "with one word" do
       let!(:runs) do
         [


### PR DESCRIPTION
Given a page that has text runs, however all are empty strings, an error was raised coercing nil to a Fixnum when trying to find the last non-empty line.

Now an empty string is returned when all lines are empty.

The error that was raised was:

```
TypeError: nil can't be coerced into Fixnum
```

on line 49 since none of the line lengths were non-zero, so the right hand side of the subtraction operation was nil.