### PR TITLE
Update rspec to 3.4 with transpec syntax conversion and manual edits

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,8 @@
-require "rubygems"
-require "bundler"
-Bundler.setup
-
-require 'yaml'
-require 'rake'
-require 'rdoc/task'
-require 'rspec/core/rake_task'
-require 'digest/md5'
+require "bundler/gem_tasks"
+require "digest/md5"
+require "rdoc/task"
+require "rspec/core/rake_task"
+require "yaml"
 
 # Cane requires ripper, which appears to only work on MRI 1.9
 if RUBY_VERSION >= "1.9" && RUBY_ENGINE == "ruby"
@@ -32,7 +28,7 @@ else
 end
 
 desc "Run all rspec files"
-RSpec::Core::RakeTask.new("spec") do |t|
+RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts  = ["--color", "--format progress"]
   t.ruby_opts = "-w"
 end

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency("rake")
   spec.add_development_dependency("rspec", "~> 3.4")
-  spec.add_development_dependency("ZenTest", "~>4.4.2")
-  spec.add_development_dependency("cane", "~>2.2.3")
+  spec.add_development_dependency("ZenTest", "~> 4.4.2")
+  spec.add_development_dependency("cane", "~> 2.6")
   spec.add_development_dependency("morecane")
   spec.add_development_dependency("ir_b")
   spec.add_development_dependency("rdoc")

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">=1.9.3"
 
   spec.add_development_dependency("rake")
-  spec.add_development_dependency("rspec", "~>2.3")
+  spec.add_development_dependency("rspec", "~> 3.4")
   spec.add_development_dependency("ZenTest", "~>4.4.2")
   spec.add_development_dependency("cane", "~>2.2.3")
   spec.add_development_dependency("morecane")

--- a/spec/buffer_spec.rb
+++ b/spec/buffer_spec.rb
@@ -10,377 +10,377 @@ describe PDF::Reader::Buffer, "token method" do
     buf = parse_string("aaa")
 
     buf.token
-    buf.token.should be_nil
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return a simple token - 1" do
     buf = parse_string("aaa")
 
-    buf.token.should eql("aaa")
-    buf.token.should be_nil
+    expect(buf.token).to eql("aaa")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return a simple token - 2" do
     buf = parse_string("1.0")
 
-    buf.token.should eql("1.0")
-    buf.token.should be_nil
+    expect(buf.token).to eql("1.0")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return two simple tokens" do
     buf = parse_string("aaa 1.0")
 
-    buf.token.should eql("aaa")
-    buf.token.should eql("1.0")
-    buf.token.should be_nil
+    expect(buf.token).to eql("aaa")
+    expect(buf.token).to eql("1.0")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly tokenise opening delimiters" do
     buf = parse_string("<[{/(")
 
-    buf.token.should eql("<")
-    buf.token.should eql(">") # auto adds closing hex string delim
-    buf.token.should eql("[")
-    buf.token.should eql("{")
-    buf.token.should eql("/")
-    buf.token.should eql("(")
-    buf.token.should eql(")") # auto adds closing literal string delim
-    buf.token.should be_nil
+    expect(buf.token).to eql("<")
+    expect(buf.token).to eql(">") # auto adds closing hex string delim
+    expect(buf.token).to eql("[")
+    expect(buf.token).to eql("{")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql(")") # auto adds closing literal string delim
+    expect(buf.token).to be_nil
   end
 
   it "should correctly tokenise closing delimiters" do
     buf = parse_string(")>]}")
 
-    buf.token.should eql(")")
-    buf.token.should eql(">")
-    buf.token.should eql("]")
-    buf.token.should eql("}")
-    buf.token.should be_nil
+    expect(buf.token).to eql(")")
+    expect(buf.token).to eql(">")
+    expect(buf.token).to eql("]")
+    expect(buf.token).to eql("}")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly tokenise hash delimiters" do
     buf = parse_string("<<aaa>>")
 
-    buf.token.should eql("<<")
-    buf.token.should eql("aaa")
-    buf.token.should eql(">>")
-    buf.token.should be_nil
+    expect(buf.token).to eql("<<")
+    expect(buf.token).to eql("aaa")
+    expect(buf.token).to eql(">>")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return simple tokens with delimiters" do
     buf = parse_string("<aaa><bbb>")
 
-    buf.token.should eql("<")
-    buf.token.should eql("aaa")
-    buf.token.should eql(">")
-    buf.token.should eql("<")
-    buf.token.should eql("bbb")
-    buf.token.should eql(">")
-    buf.token.should be_nil
+    expect(buf.token).to eql("<")
+    expect(buf.token).to eql("aaa")
+    expect(buf.token).to eql(">")
+    expect(buf.token).to eql("<")
+    expect(buf.token).to eql("bbb")
+    expect(buf.token).to eql(">")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return two name tokens" do
     buf = parse_string("/Type/Pages")
 
-    buf.token.should eql("/")
-    buf.token.should eql("Type")
-    buf.token.should eql("/")
-    buf.token.should eql("Pages")
-    buf.token.should be_nil
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("Type")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("Pages")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return two empty name tokens" do
     buf = parse_string("/ /")
 
-    buf.token.should eql("/")
-    buf.token.should eql("")
-    buf.token.should eql("/")
-    buf.token.should eql("")
-    buf.token.should be_nil
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("")
+    expect(buf.token).to be_nil
 
     buf = parse_string("/\n/")
-    buf.token.should eql("/")
-    buf.token.should eql("")
-    buf.token.should eql("/")
-    buf.token.should eql("")
-    buf.token.should be_nil
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("")
+    expect(buf.token).to be_nil
   end
 
   it "should tokenise a dict correctly" do
     buf = parse_string("/Registry (Adobe) /Ordering (Japan1) /Supplement")
-    buf.token.should eql("/")
-    buf.token.should eql("Registry")
-    buf.token.should eql("(")
-    buf.token.should eql("Adobe")
-    buf.token.should eql(")")
-    buf.token.should eql("/")
-    buf.token.should eql("Ordering")
-    buf.token.should eql("(")
-    buf.token.should eql("Japan1")
-    buf.token.should eql(")")
-    buf.token.should eql("/")
-    buf.token.should eql("Supplement")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("Registry")
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("Adobe")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("Ordering")
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("Japan1")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("Supplement")
   end
 
   it "should tokenise a string without a % correctly" do
     buf = parse_string("(James)")
-    buf.token.should eql("(")
-    buf.token.should eql("James")
-    buf.token.should eql(")")
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("James")
+    expect(buf.token).to eql(")")
   end
 
   it "should tokenise a literal string with a % correctly" do
     buf = parse_string("(James%Healy)")
-    buf.token.should eql("(")
-    buf.token.should eql("James%Healy")
-    buf.token.should eql(")")
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("James%Healy")
+    expect(buf.token).to eql(")")
   end
 
   it "should tokenise a hex string with a space correctly" do
     buf = parse_string("<AA BB>")
-    buf.token.should eql("<")
-    buf.token.should eql("AABB")
-    buf.token.should eql(">")
+    expect(buf.token).to eql("<")
+    expect(buf.token).to eql("AABB")
+    expect(buf.token).to eql(">")
   end
 
   it "should tokenise a string with comments correctly" do
     buf = parse_string("(James%Healy) % this is a comment\n(")
-    buf.token.should eql("(")
-    buf.token.should eql("James%Healy")
-    buf.token.should eql(")")
-    buf.token.should eql("(")
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("James%Healy")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to eql("(")
   end
 
   it "should tokenise a string with comments correctly" do
     buf = parse_string("James % this is a comment")
-    buf.token.should eql("James")
-    buf.token.should be_nil
+    expect(buf.token).to eql("James")
+    expect(buf.token).to be_nil
   end
 
   it "should tokenise a string with an escaped, unbalanced param correctly" do
     buf = parse_string("(James \\(Code Monkey)")
-    buf.token.should eql("(")
-    buf.token.should eql("James \\(Code Monkey")
-    buf.token.should eql(")")
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("James \\(Code Monkey")
+    expect(buf.token).to eql(")")
   end
 
   it "should correctly return an indirect reference" do
     buf = parse_string("aaa 1 0 R bbb")
 
-    buf.token.should eql("aaa")
-    buf.token.should be_a_kind_of(PDF::Reader::Reference)
-    buf.token.should eql("bbb")
-    buf.token.should be_nil
+    expect(buf.token).to eql("aaa")
+    expect(buf.token).to be_a_kind_of(PDF::Reader::Reference)
+    expect(buf.token).to eql("bbb")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return two indirect references" do
     buf = parse_string("1 0 R 2 0 R")
 
-    buf.token.should be_a_kind_of(PDF::Reader::Reference)
-    buf.token.should be_a_kind_of(PDF::Reader::Reference)
-    buf.token.should be_nil
+    expect(buf.token).to be_a_kind_of(PDF::Reader::Reference)
+    expect(buf.token).to be_a_kind_of(PDF::Reader::Reference)
+    expect(buf.token).to be_nil
   end
 
   it "should correctly seek to a particular byte of the IO - 1" do
     str = "aaa bbb ccc"
     buf = PDF::Reader::Buffer.new(StringIO.new(str), :seek => 4)
 
-    buf.token.should eql("bbb")
-    buf.token.should eql("ccc")
-    buf.token.should be_nil
+    expect(buf.token).to eql("bbb")
+    expect(buf.token).to eql("ccc")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly seek to a particular byte of the IO - 2" do
     str = "aaa bbb ccc"
     buf = PDF::Reader::Buffer.new(StringIO.new(str), :seek => 5)
 
-    buf.token.should eql("bb")
-    buf.token.should eql("ccc")
-    buf.token.should be_nil
+    expect(buf.token).to eql("bb")
+    expect(buf.token).to eql("ccc")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return a simple literal string" do
     buf = parse_string("(aaa)")
 
-    buf.token.should eql("(")
-    buf.token.should eql("aaa")
-    buf.token.should eql(")")
-    buf.token.should be_nil
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("aaa")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return an empty literal string" do
     buf = parse_string("()")
 
-    buf.token.should eql("(")
-    buf.token.should eql(")")
-    buf.token.should be_nil
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return a simple literal string with spaces" do
     buf = parse_string("(aaa bbb)")
 
-    buf.token.should eql("(")
-    buf.token.should eql("aaa bbb")
-    buf.token.should eql(")")
-    buf.token.should be_nil
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("aaa bbb")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return a simple literal string with nested brackets" do
     buf = parse_string("(aaa (bbb))")
 
-    buf.token.should eql("(")
-    buf.token.should eql("aaa (bbb)")
-    buf.token.should eql(")")
-    buf.token.should be_nil
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("aaa (bbb)")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return a literal string with escaped slash followed by a closing brace" do
     buf = parse_string("(aaa\x5C\x5C)")
 
-    buf.token.should eql("(")
-    buf.token.should eql("aaa\x5C\x5C")
-    buf.token.should eql(")")
-    buf.token.should be_nil
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("aaa\x5C\x5C")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return a literal string with three slashes followed by a closing brace" do
     buf = parse_string("(aaa\x5C\x5C\x5C))")
 
-    buf.token.should eql("(")
-    buf.token.should eql("aaa\x5C\x5C\x5C)")
-    buf.token.should eql(")")
-    buf.token.should be_nil
+    expect(buf.token).to eql("(")
+    expect(buf.token).to eql("aaa\x5C\x5C\x5C)")
+    expect(buf.token).to eql(")")
+    expect(buf.token).to be_nil
   end
 
   it "should correctly return a dictionary with embedded hex string" do
     buf = parse_string("<< /X <48656C6C6F> >>")
-    buf.token.should eql("<<")
-    buf.token.should eql("/")
-    buf.token.should eql("X")
-    buf.token.should eql("<")
-    buf.token.should eql("48656C6C6F")
-    buf.token.should eql(">")
-    buf.token.should eql(">>")
+    expect(buf.token).to eql("<<")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("X")
+    expect(buf.token).to eql("<")
+    expect(buf.token).to eql("48656C6C6F")
+    expect(buf.token).to eql(">")
+    expect(buf.token).to eql(">>")
   end
   it "should correctly return a dictionary with embedded hex string" do
     buf = parse_string("/Span<</ActualText<FEFF0009>>> BDC")
-    buf.token.should eql("/")
-    buf.token.should eql("Span")
-    buf.token.should eql("<<")
-    buf.token.should eql("/")
-    buf.token.should eql("ActualText")
-    buf.token.should eql("<")
-    buf.token.should eql("FEFF0009")
-    buf.token.should eql(">")
-    buf.token.should eql(">>")
-    buf.token.should eql("BDC")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("Span")
+    expect(buf.token).to eql("<<")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("ActualText")
+    expect(buf.token).to eql("<")
+    expect(buf.token).to eql("FEFF0009")
+    expect(buf.token).to eql(">")
+    expect(buf.token).to eql(">>")
+    expect(buf.token).to eql("BDC")
   end
 
   it "should correctly return a dictionary with an indirect reference" do
     buf = parse_string("<< /X 10 0 R >>")
-    buf.token.should eql("<<")
-    buf.token.should eql("/")
-    buf.token.should eql("X")
-    buf.token.should be_a_kind_of(PDF::Reader::Reference)
-    buf.token.should eql(">>")
+    expect(buf.token).to eql("<<")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("X")
+    expect(buf.token).to be_a_kind_of(PDF::Reader::Reference)
+    expect(buf.token).to eql(">>")
   end
 
   it "should correctly return a dictionary with an indirect reference and more than 10 tokens" do
     buf = parse_string("<< /X 10 0 R /Y 11 0 R /Z 12 0 R >>")
-    buf.token.should eql("<<")
-    buf.token.should eql("/")
-    buf.token.should eql("X")
-    buf.token.should be_a_kind_of(PDF::Reader::Reference)
-    buf.token.should eql("/")
-    buf.token.should eql("Y")
-    buf.token.should be_a_kind_of(PDF::Reader::Reference)
-    buf.token.should eql("/")
-    buf.token.should eql("Z")
-    buf.token.should be_a_kind_of(PDF::Reader::Reference)
-    buf.token.should eql(">>")
+    expect(buf.token).to eql("<<")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("X")
+    expect(buf.token).to be_a_kind_of(PDF::Reader::Reference)
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("Y")
+    expect(buf.token).to be_a_kind_of(PDF::Reader::Reference)
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("Z")
+    expect(buf.token).to be_a_kind_of(PDF::Reader::Reference)
+    expect(buf.token).to eql(">>")
   end
 
   it "should record io position" do
     buf = parse_string("aaa bbb")
 
-    buf.pos.should eql(0)
+    expect(buf.pos).to eql(0)
     buf.token
-    buf.pos.should eql(7)
+    expect(buf.pos).to eql(7)
   end
 
   it "should restore io position if it's been changed on us" do
     io = StringIO.new("aaa bbb")
     buf = PDF::Reader::Buffer.new(io)
 
-    buf.pos.should eql(0)
+    expect(buf.pos).to eql(0)
     buf.token
     buf.token
-    buf.pos.should eql(7)
+    expect(buf.pos).to eql(7)
     io.seek(0)
 
-    buf.token.should be_nil
-    buf.pos.should eql(7)
+    expect(buf.token).to be_nil
+    expect(buf.pos).to eql(7)
   end
 
   it "should correctly tokenise an inline image when inside a content stream" do
     io = StringIO.new(binary_string("BI ID aaa bbb ccc \xF0\xF0\xF0 EI"))
     buf = PDF::Reader::Buffer.new(io, :content_stream => true)
 
-    buf.pos.should eql(0)
-    buf.token.should eql("BI")
-    buf.token.should eql("ID")
-    buf.token.should eql(binary_string("aaa bbb ccc \xF0\xF0\xF0"))
-    buf.token.should eql("EI")
+    expect(buf.pos).to eql(0)
+    expect(buf.token).to eql("BI")
+    expect(buf.token).to eql("ID")
+    expect(buf.token).to eql(binary_string("aaa bbb ccc \xF0\xF0\xF0"))
+    expect(buf.token).to eql("EI")
   end
 
   it "should correctly tokenise an inline image when outside a content stream" do
     io = StringIO.new(binary_string("BI ID aaa bbb ccc \xF0\xF0\xF0 EI"))
     buf = PDF::Reader::Buffer.new(io, :content_stream => false)
 
-    buf.pos.should eql(0)
-    buf.token.should eql("BI")
-    buf.token.should eql("ID")
-    buf.token.should eql("aaa")
-    buf.token.should eql("bbb")
-    buf.token.should eql("ccc")
-    buf.token.should eql(binary_string("\xF0\xF0\xF0"))
-    buf.token.should eql("EI")
+    expect(buf.pos).to eql(0)
+    expect(buf.token).to eql("BI")
+    expect(buf.token).to eql("ID")
+    expect(buf.token).to eql("aaa")
+    expect(buf.token).to eql("bbb")
+    expect(buf.token).to eql("ccc")
+    expect(buf.token).to eql(binary_string("\xF0\xF0\xF0"))
+    expect(buf.token).to eql("EI")
   end
 
   it "should correctly tokenise an inline image that contains the letters 'EI' within the image data" do
     io = StringIO.new(binary_string("BI ID aaa bbb ccc \xF0EI\xF0 EI"))
     buf = PDF::Reader::Buffer.new(io, :content_stream => true)
 
-    buf.pos.should eql(0)
-    buf.token.should eql("BI")
-    buf.token.should eql("ID")
-    buf.token.should eql(binary_string("aaa bbb ccc \xF0EI\xF0"))
-    buf.token.should eql("EI")
+    expect(buf.pos).to eql(0)
+    expect(buf.token).to eql("BI")
+    expect(buf.token).to eql("ID")
+    expect(buf.token).to eql(binary_string("aaa bbb ccc \xF0EI\xF0"))
+    expect(buf.token).to eql("EI")
   end
 
   it "should correctly tokenise an inline image that contains the letters 'EI' within the image data" do
     io = StringIO.new(binary_string("BI ID aaa bbb ccc \xF0EI\xF0\nEI"))
     buf = PDF::Reader::Buffer.new(io, :content_stream => true)
 
-    buf.pos.should eql(0)
-    buf.token.should eql("BI")
-    buf.token.should eql("ID")
-    buf.token.should eql(binary_string("aaa bbb ccc \xF0EI\xF0"))
-    buf.token.should eql("EI")
+    expect(buf.pos).to eql(0)
+    expect(buf.token).to eql("BI")
+    expect(buf.token).to eql("ID")
+    expect(buf.token).to eql(binary_string("aaa bbb ccc \xF0EI\xF0"))
+    expect(buf.token).to eql("EI")
   end
 
   it "should correctly tokenise a hash that has ID as a key" do
     io = StringIO.new("<</ID /S1 >> BDC")
     buf = PDF::Reader::Buffer.new(io, :content_stream => true)
 
-    buf.pos.should eql(0)
-    buf.token.should eql("<<")
-    buf.token.should eql("/")
-    buf.token.should eql("ID")
-    buf.token.should eql("/")
-    buf.token.should eql("S1")
-    buf.token.should eql(">>")
-    buf.token.should eql("BDC")
+    expect(buf.pos).to eql(0)
+    expect(buf.token).to eql("<<")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("ID")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("S1")
+    expect(buf.token).to eql(">>")
+    expect(buf.token).to eql("BDC")
   end
 end
 
@@ -390,15 +390,15 @@ describe PDF::Reader::Buffer, "empty? method" do
   it "should correctly return false if there are remaining tokens" do
     buf = parse_string("aaa")
 
-    buf.empty?.should be_false
+    expect(buf.empty?).to be_falsey
   end
 
   it "should correctly return true if there are no remaining tokens" do
     buf = parse_string("aaa")
 
-    buf.empty?.should be_false
+    expect(buf.empty?).to be_falsey
     buf.token
-    buf.empty?.should be_true
+    expect(buf.empty?).to be_truthy
   end
 end
 
@@ -408,72 +408,72 @@ describe PDF::Reader::Buffer, "find_first_xref_offset method" do
     @file = File.new(pdf_spec_file("cairo-basic"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    @buffer.find_first_xref_offset.should eql(9243)
+    expect(@buffer.find_first_xref_offset).to eql(9243)
   end
 
   it "should find the first xref offset from cairo-unicode.pdf correctly" do
     @file = File.new(pdf_spec_file("cairo-unicode"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    @buffer.find_first_xref_offset.should eql(136174)
+    expect(@buffer.find_first_xref_offset).to eql(136174)
   end
 
   it "should find the first xref offset from prince1.pdf correctly" do
     @file = File.new(pdf_spec_file("prince1"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    @buffer.find_first_xref_offset.should eql(678715)
+    expect(@buffer.find_first_xref_offset).to eql(678715)
   end
 
   it "should find the first xref offset from prince2.pdf correctly" do
     @file = File.new(pdf_spec_file("prince2"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    @buffer.find_first_xref_offset.should eql(941440)
+    expect(@buffer.find_first_xref_offset).to eql(941440)
   end
 
   it "should find the first xref offset from pdfwriter-manual.pdf correctly" do
     @file = File.new(pdf_spec_file("pdfwriter-manual"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    @buffer.find_first_xref_offset.should eql(275320)
+    expect(@buffer.find_first_xref_offset).to eql(275320)
   end
 
   it "should find the first xref offset from pdf-distiller.pdf correctly" do
     @file = File.new(pdf_spec_file("pdf-distiller"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    @buffer.find_first_xref_offset.should eql(173)
+    expect(@buffer.find_first_xref_offset).to eql(173)
   end
 
   it "should find the first xref offset from pdflatex.pdf correctly" do
     @file = File.new(pdf_spec_file("pdflatex"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    @buffer.find_first_xref_offset.should eql(152898)
+    expect(@buffer.find_first_xref_offset).to eql(152898)
   end
 
   it "should find the first xref offset from openoffice-2.2.pdf correctly" do
     @file = File.new(pdf_spec_file("openoffice-2.2"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    @buffer.find_first_xref_offset.should eql(36961)
+    expect(@buffer.find_first_xref_offset).to eql(36961)
   end
 
   it "should raise an exception when buffer doesn't contain an EOF marker" do
     @file = File.new(pdf_spec_file("no_eof"))
     @buffer = PDF::Reader::Buffer.new(@file)
 
-    lambda { @buffer.find_first_xref_offset }.should raise_error(PDF::Reader::MalformedPDFError)
+    expect { @buffer.find_first_xref_offset }.to raise_error(PDF::Reader::MalformedPDFError)
   end
 
   it "should match EOF markers when they have a suffix" do
     file   = File.new pdf_spec_file("extended_eof")
     buffer = PDF::Reader::Buffer.new file
 
-    lambda {
+    expect {
       buffer.find_first_xref_offset
-    }.should_not raise_error
+    }.not_to raise_error
   end
 end
 
@@ -483,42 +483,42 @@ describe PDF::Reader::Buffer, "read method" do
   it "should return raw data from the underlying IO" do
     buf = parse_string("stream bbb")
 
-    buf.token.should eql("stream")
-    buf.read(3).should eql("bbb")
+    expect(buf.token).to eql("stream")
+    expect(buf.read(3)).to eql("bbb")
   end
 
   it "should return raw data from the underlying IO" do
     buf = parse_string("stream\n\nbbb")
 
-    buf.token.should eql("stream")
-    buf.read(4).should eql("\nbbb")
+    expect(buf.token).to eql("stream")
+    expect(buf.read(4)).to eql("\nbbb")
   end
 
   it "should return raw data from the underlying IO and skip LF/CR bytes" do
     buf = parse_string("stream\nbbb")
 
-    buf.token.should eql("stream")
-    buf.read(3, :skip_eol => true).should eql("bbb")
+    expect(buf.token).to eql("stream")
+    expect(buf.read(3, :skip_eol => true)).to eql("bbb")
   end
 
   it "should return raw data from the underlying IO and skip LF/CR bytes" do
     buf = parse_string("stream\r\nbbb")
 
-    buf.token.should eql("stream")
-    buf.read(3, :skip_eol => true).should eql("bbb")
+    expect(buf.token).to eql("stream")
+    expect(buf.read(3, :skip_eol => true)).to eql("bbb")
   end
 
   it "should return raw data from the underlying IO and skip LF/CR bytes" do
     buf = parse_string("stream\n\nbbb")
 
-    buf.token.should eql("stream")
-    buf.read(4, :skip_eol => true).should eql("\nbbb")
+    expect(buf.token).to eql("stream")
+    expect(buf.read(4, :skip_eol => true)).to eql("\nbbb")
   end
 
   it "should return raw data from the underlying IO and skip LF/CR bytes" do
     buf = parse_string("stream\n\n\nbbb")
 
-    buf.token.should eql("stream")
-    buf.read(5, :skip_eol => true).should eql("\n\nbbb")
+    expect(buf.token).to eql("stream")
+    expect(buf.read(5, :skip_eol => true)).to eql("\n\nbbb")
   end
 end

--- a/spec/callback_spec.rb
+++ b/spec/callback_spec.rb
@@ -63,7 +63,7 @@ describe PDF::Reader do
         receiver.all_args(:page_count).each do |args|
           expect(args.size).to eq 1
           expect(args[0]).to be_a(Fixnum)
-          expect(args[0] > 0).to  be_true
+          expect(args[0] > 0).to be true
         end
 
       end

--- a/spec/cid_widths_spec.rb
+++ b/spec/cid_widths_spec.rb
@@ -7,7 +7,7 @@ describe PDF::Reader::CidWidths, "#initilize" do
     subject { PDF::Reader::CidWidths.new(500, [])}
 
     it "should return the default width" do
-      subject[1].should == 500
+      expect(subject[1]).to eq(500)
     end
   end
 
@@ -15,19 +15,19 @@ describe PDF::Reader::CidWidths, "#initilize" do
     subject { PDF::Reader::CidWidths.new(500, [1, [10, 20, 30]])}
 
     it "should return correct width for index 1" do
-      subject[1].should == 10
+      expect(subject[1]).to eq(10)
     end
 
     it "should return correct width for index 2" do
-      subject[2].should == 20
+      expect(subject[2]).to eq(20)
     end
 
     it "should return correct width for index 3" do
-      subject[3].should == 30
+      expect(subject[3]).to eq(30)
     end
 
     it "should return correct width for index 4" do
-      subject[4].should == 500
+      expect(subject[4]).to eq(500)
     end
   end
 
@@ -35,19 +35,19 @@ describe PDF::Reader::CidWidths, "#initilize" do
     subject { PDF::Reader::CidWidths.new(500, [1, 3, 10])}
 
     it "should return correct width for index 1" do
-      subject[1].should == 10
+      expect(subject[1]).to eq(10)
     end
 
     it "should return correct width for index 2" do
-      subject[2].should == 10
+      expect(subject[2]).to eq(10)
     end
 
     it "should return correct width for index 3" do
-      subject[3].should == 10
+      expect(subject[3]).to eq(10)
     end
 
     it "should return correct width for index 4" do
-      subject[4].should == 500
+      expect(subject[4]).to eq(500)
     end
   end
 
@@ -61,31 +61,31 @@ describe PDF::Reader::CidWidths, "#initilize" do
     subject       { PDF::Reader::CidWidths.new(500, widths)}
 
     it "should return correct width for index 1" do
-      subject[1].should == 10
+      expect(subject[1]).to eq(10)
     end
 
     it "should return correct width for index 2" do
-      subject[2].should == 20
+      expect(subject[2]).to eq(20)
     end
 
     it "should return correct width for index 3" do
-      subject[3].should == 30
+      expect(subject[3]).to eq(30)
     end
 
     it "should return correct width for index 4" do
-      subject[4].should == 40
+      expect(subject[4]).to eq(40)
     end
 
     it "should return correct width for index 5" do
-      subject[5].should == 40
+      expect(subject[5]).to eq(40)
     end
 
     it "should return correct width for index 6" do
-      subject[6].should == 40
+      expect(subject[6]).to eq(40)
     end
 
     it "should return correct width for index 7" do
-      subject[7].should == 500
+      expect(subject[7]).to eq(500)
     end
   end
 

--- a/spec/cmap_spec.rb
+++ b/spec/cmap_spec.rb
@@ -7,76 +7,76 @@ describe "PDF::Reader::CMap with a bfchar cmap" do
   it "should correctly load a cmap object string" do
     filename = File.dirname(__FILE__) + "/data/cmap_with_bfchar.txt"
     map = PDF::Reader::CMap.new(binread(filename))
-    map.map.should be_a_kind_of(Hash)
-    map.size.should     == 9
-    map.map[0x1].should == [0x48]
-    map.map[0x2].should == [0x65]
-    map.map[0x9].should == [0x73]
+    expect(map.map).to be_a_kind_of(Hash)
+    expect(map.size).to     eq(9)
+    expect(map.map[0x1]).to eq([0x48])
+    expect(map.map[0x2]).to eq([0x65])
+    expect(map.map[0x9]).to eq([0x73])
   end
 
   it "should correctly convert a character code into a unicode codepoint" do
     filename = File.dirname(__FILE__) + "/data/cmap_with_bfchar.txt"
     map = PDF::Reader::CMap.new(binread(filename))
-    map.decode(0x1).should == [0x48]
-    map.decode(0x2).should == [0x65]
-    map.decode(0x9).should == [0x73]
+    expect(map.decode(0x1)).to eq([0x48])
+    expect(map.decode(0x2)).to eq([0x65])
+    expect(map.decode(0x9)).to eq([0x73])
   end
 
   it "should correctly load a cmap that uses the beginbfrange operator" do
     filename = File.dirname(__FILE__) + "/data/cmap_with_bfrange.txt"
     map = PDF::Reader::CMap.new(binread(filename))
-    map.decode(0x16C9).should == [0x4F38] # mapped with the bfchar operator
-    map.decode(0x0003).should == [0x0020] # mapped with the bfrange operator
-    map.decode(0x0004).should == [0x0020+1] # mapped with the bfrange operator
-    map.decode(0x0005).should == [0x0020+2] # mapped with the bfrange operator
+    expect(map.decode(0x16C9)).to eq([0x4F38]) # mapped with the bfchar operator
+    expect(map.decode(0x0003)).to eq([0x0020]) # mapped with the bfrange operator
+    expect(map.decode(0x0004)).to eq([0x0020+1]) # mapped with the bfrange operator
+    expect(map.decode(0x0005)).to eq([0x0020+2]) # mapped with the bfrange operator
   end
 
   it "should correctly load a cmap that uses the beginbfrange operator" do
     filename = File.dirname(__FILE__) + "/data/cmap_with_bfrange_two.txt"
     map = PDF::Reader::CMap.new(binread(filename))
-    map.decode(0x0100).should == [0x0100] # mapped with the bfrange operator
+    expect(map.decode(0x0100)).to eq([0x0100]) # mapped with the bfrange operator
   end
 
   it "should correctly load a cmap that uses the beginbfrange operator with the array syntax" do
     filename = File.dirname(__FILE__) + "/data/cmap_with_bfrange_three.txt"
     map = PDF::Reader::CMap.new(binread(filename))
 
-    map.size.should eql(256)
-    map.decode(0x00).should == [0xfffd] # mapped with the bfrange operator
-    map.decode(0x01).should == [0x0050] # mapped with the bfrange operator
-    map.decode(0x03).should == [0x0067] # mapped with the bfrange operator
-    map.decode(0x08).should == [0x0073] # mapped with the bfrange operator
+    expect(map.size).to eql(256)
+    expect(map.decode(0x00)).to eq([0xfffd]) # mapped with the bfrange operator
+    expect(map.decode(0x01)).to eq([0x0050]) # mapped with the bfrange operator
+    expect(map.decode(0x03)).to eq([0x0067]) # mapped with the bfrange operator
+    expect(map.decode(0x08)).to eq([0x0073]) # mapped with the bfrange operator
   end
 
   it "should correctly load a cmap that has ligatures in it" do
     filename = File.dirname(__FILE__) + "/data/cmap_with_ligatures.txt"
     map = PDF::Reader::CMap.new(binread(filename))
 
-    map.decode(0x00B7).should eql([0x2019])
-    map.decode(0x00C0).should eql([0x66, 0x69])
-    map.decode(0x00C1).should eql([0x66, 0x6C])
+    expect(map.decode(0x00B7)).to eql([0x2019])
+    expect(map.decode(0x00C0)).to eql([0x66, 0x69])
+    expect(map.decode(0x00C1)).to eql([0x66, 0x6C])
   end
 
   it "should correctly load a cmap that has surrogate pairs in it" do
     filename = File.dirname(__FILE__) + "/data/cmap_with_surrogate_pairs.txt"
     map = PDF::Reader::CMap.new(binread(filename))
 
-    map.decode(0x0502).should eql([0x03D1])
-    map.decode(0x0C09).should eql([0x1D6FD])
-    map.decode(0x0723).should eql([0x1D434])
-    map.decode(0x0C23).should eql([0x1D717])
-    map.decode(0x0526).should eql([0x20D7])
-    map.decode(0x072B).should eql([0x1D43C])
-    map.decode(0x122C).should eql([0xFFFD])
+    expect(map.decode(0x0502)).to eql([0x03D1])
+    expect(map.decode(0x0C09)).to eql([0x1D6FD])
+    expect(map.decode(0x0723)).to eql([0x1D434])
+    expect(map.decode(0x0C23)).to eql([0x1D717])
+    expect(map.decode(0x0526)).to eql([0x20D7])
+    expect(map.decode(0x072B)).to eql([0x1D43C])
+    expect(map.decode(0x122C)).to eql([0xFFFD])
   end
 
   it "should correctly load a cmap that has a bfrange with > 255 characters" do
     filename = File.dirname(__FILE__) + "/data/cmap_with_large_bfrange.txt"
     map = PDF::Reader::CMap.new(binread(filename))
 
-    map.decode(0x00B7).should eql([0x00B7])
-    map.decode(0x00C0).should eql([0x00C0])
-    map.decode(0x00C1).should eql([0x00C1])
+    expect(map.decode(0x00B7)).to eql([0x00B7])
+    expect(map.decode(0x00C0)).to eql([0x00C0])
+    expect(map.decode(0x00C1)).to eql([0x00C1])
   end
 
 end

--- a/spec/column_spec.rb
+++ b/spec/column_spec.rb
@@ -10,7 +10,7 @@ describe PDF::Reader, "column specs" do
 
       PDF::Reader.open(filename) do |reader|
         page = reader.page(1)
-        page.text.should =~ /Some Headline/
+        expect(page.text).to match(/Some Headline/)
       end
     end
     it "should correctly extract the first few lines" do
@@ -19,12 +19,12 @@ describe PDF::Reader, "column specs" do
       PDF::Reader.open(filename) do |reader|
         page = reader.page(1)
         ft = page.text
-        ft.should =~ /ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu/
-        ft.should =~ /Lorem ipsum dolor sit amet, consectetur adipisic -\s+adipisicing elit, sed do eiusmod tempor incididunt/
-        ft.should =~ /ing elit, sed do eiusmod tempor incididunt ut labore\s+ut labore et dolore magna aliqua. Ut enim ad minim/
-        ft.should =~ /et dolore magna aliqua. Ut enim ad minim veniam,\s+veniam, quis nostrud exercitation ullamco laboris/
-        ft.should =~ /quis nostrud exercitation ullamco laboris nisi ut\s+nisi ut aliquip ex ea commodo consequat. Duis aute/
-        ft.should =~ /aliquip ex ea commodo consequat. Duis aute irure\s+irure dolor in reprehenderit in voluptate velit esse/
+        expect(ft).to match(/ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu/)
+        expect(ft).to match(/Lorem ipsum dolor sit amet, consectetur adipisic -\s+adipisicing elit, sed do eiusmod tempor incididunt/)
+        expect(ft).to match(/ing elit, sed do eiusmod tempor incididunt ut labore\s+ut labore et dolore magna aliqua. Ut enim ad minim/)
+        expect(ft).to match(/et dolore magna aliqua. Ut enim ad minim veniam,\s+veniam, quis nostrud exercitation ullamco laboris/)
+        expect(ft).to match(/quis nostrud exercitation ullamco laboris nisi ut\s+nisi ut aliquip ex ea commodo consequat. Duis aute/)
+        expect(ft).to match(/aliquip ex ea commodo consequat. Duis aute irure\s+irure dolor in reprehenderit in voluptate velit esse/)
       end
     end
 
@@ -42,11 +42,11 @@ describe PDF::Reader, "column specs" do
         match_pos_4 = find_position_of_match(ft, /nisi ut aliquip ex ea commodo consequat. Duis aute$/)
         match_pos_5 = find_position_of_match(ft, /irure dolor in reprehenderit in voluptate velit esse$/)
 
-        match_pos_1.should_not be_nil
-        match_pos_1.should eql(match_pos_2)
-        match_pos_1.should eql(match_pos_3)
-        match_pos_1.should eql(match_pos_4)
-        match_pos_1.should eql(match_pos_5)
+        expect(match_pos_1).not_to be_nil
+        expect(match_pos_1).to eql(match_pos_2)
+        expect(match_pos_1).to eql(match_pos_3)
+        expect(match_pos_1).to eql(match_pos_4)
+        expect(match_pos_1).to eql(match_pos_5)
       end
     end
   end
@@ -64,10 +64,10 @@ describe PDF::Reader, "column specs" do
         col1_3   = find_position_of_match(ft, /^sint occaecat cupidatat non proi -/)
         col1_4   = find_position_of_match(ft, /^dent, sunt in culpa qui officia de-/)
 
-        col1_1.should_not be_nil
-        col1_1.should eql(col1_2)
-        col1_1.should eql(col1_3)
-        col1_1.should eql(col1_4)
+        expect(col1_1).not_to be_nil
+        expect(col1_1).to eql(col1_2)
+        expect(col1_1).to eql(col1_3)
+        expect(col1_1).to eql(col1_4)
       end
     end
     it "should correctly align text in column 2" do
@@ -82,10 +82,10 @@ describe PDF::Reader, "column specs" do
         col2_3   = find_position_of_match(ft, /mollit anim id est laborum. Lo -\s*adipisicing/)
         col2_4   = find_position_of_match(ft, /rem ipsum dolor sit amet, con -\s*tempor/)
 
-        col2_1.should_not be_nil
-        col2_1.should eql(col2_2)
-        col2_1.should eql(col2_3)
-        col2_1.should eql(col2_4)
+        expect(col2_1).not_to be_nil
+        expect(col2_1).to eql(col2_2)
+        expect(col2_1).to eql(col2_3)
+        expect(col2_1).to eql(col2_4)
       end
     end
 
@@ -101,10 +101,10 @@ describe PDF::Reader, "column specs" do
         col3_a_3 = find_position_of_match(ft, /adipisicing elit, sed do eiusmod$/)
         col3_a_4 = find_position_of_match(ft, /tempor incididunt ut labore et$/)
 
-        col3_a_1.should_not be_nil
-        col3_a_1.should eql(col3_a_2)
-        col3_a_1.should eql(col3_a_3)
-        col3_a_1.should eql(col3_a_4)
+        expect(col3_a_1).not_to be_nil
+        expect(col3_a_1).to eql(col3_a_2)
+        expect(col3_a_1).to eql(col3_a_3)
+        expect(col3_a_1).to eql(col3_a_4)
       end
     end
 
@@ -120,10 +120,10 @@ describe PDF::Reader, "column specs" do
         col3_b_3 = find_position_of_match(ft, /\s{10}quis nostrud exercitation$/)
         col3_b_4 = find_position_of_match(ft, /\s{10}ullamco laboris nisi ut$/)
 
-        col3_b_1.should_not be_nil
-        col3_b_1.should eql(col3_b_2)
-        col3_b_1.should eql(col3_b_3)
-        col3_b_1.should eql(col3_b_4)
+        expect(col3_b_1).not_to be_nil
+        expect(col3_b_1).to eql(col3_b_2)
+        expect(col3_b_1).to eql(col3_b_3)
+        expect(col3_b_1).to eql(col3_b_4)
       end
     end
   end

--- a/spec/deprecated_reader_spec.rb
+++ b/spec/deprecated_reader_spec.rb
@@ -11,32 +11,32 @@ describe PDF::Reader, "file class method" do
 
   it "should parse all aspects of a PDF file by default" do
     PDF::Reader.file(@filename, @receiver)
-    @receiver.count(:begin_document).should eql(1)
-    @receiver.count(:metadata).should eql(1)
+    expect(@receiver.count(:begin_document)).to eql(1)
+    expect(@receiver.count(:metadata)).to eql(1)
   end
 
   it "should not provide raw text callbacks by default" do
     PDF::Reader.file(@filename, @receiver)
-    @receiver.count(:show_text_with_positioning).should eql(1)
-    @receiver.count(:show_text_with_positioning_raw).should eql(0)
+    expect(@receiver.count(:show_text_with_positioning)).to eql(1)
+    expect(@receiver.count(:show_text_with_positioning_raw)).to eql(0)
   end
 
   it "should provide raw text callbacks if requested" do
     PDF::Reader.file(@filename, @receiver, :raw_text => true)
-    @receiver.count(:show_text_with_positioning).should eql(1)
-    @receiver.count(:show_text_with_positioning_raw).should eql(1)
+    expect(@receiver.count(:show_text_with_positioning)).to eql(1)
+    expect(@receiver.count(:show_text_with_positioning_raw)).to eql(1)
   end
 
   it "should not parse metadata if requested" do
     PDF::Reader.file(@filename, @receiver, :metadata => false)
-    @receiver.count(:begin_document).should eql(1)
-    @receiver.count(:metadata).should eql(0)
+    expect(@receiver.count(:begin_document)).to eql(1)
+    expect(@receiver.count(:metadata)).to eql(0)
   end
 
   it "should not parse page content if requested" do
     PDF::Reader.file(@filename, @receiver, :pages => false)
-    @receiver.count(:begin_document).should eql(0)
-    @receiver.count(:metadata).should eql(1)
+    expect(@receiver.count(:begin_document)).to eql(0)
+    expect(@receiver.count(:metadata)).to eql(1)
   end
 
 end
@@ -48,32 +48,32 @@ describe PDF::Reader, "string class method" do
 
   it "should parse all aspects of a PDF file by default" do
     PDF::Reader.string(data, receiver)
-    receiver.count(:begin_document).should eql(1)
-    receiver.count(:metadata).should eql(1)
+    expect(receiver.count(:begin_document)).to eql(1)
+    expect(receiver.count(:metadata)).to eql(1)
   end
 
   it "should not provide raw text callbacks by default" do
     PDF::Reader.string(data, receiver)
-    receiver.count(:show_text_with_positioning).should eql(1)
-    receiver.count(:show_text_with_positioning_raw).should eql(0)
+    expect(receiver.count(:show_text_with_positioning)).to eql(1)
+    expect(receiver.count(:show_text_with_positioning_raw)).to eql(0)
   end
 
   it "should provide raw text callbacks if requested" do
     PDF::Reader.string(data, receiver, :raw_text => true)
-    receiver.count(:show_text_with_positioning).should eql(1)
-    receiver.count(:show_text_with_positioning_raw).should eql(1)
+    expect(receiver.count(:show_text_with_positioning)).to eql(1)
+    expect(receiver.count(:show_text_with_positioning_raw)).to eql(1)
   end
 
   it "should parse not parse metadata if requested" do
     PDF::Reader.string(data, receiver, :metadata => false)
-    receiver.count(:begin_document).should eql(1)
-    receiver.count(:metadata).should eql(0)
+    expect(receiver.count(:begin_document)).to eql(1)
+    expect(receiver.count(:metadata)).to eql(0)
   end
 
   it "should parse not parse page content if requested" do
     PDF::Reader.string(data, receiver, :pages => false)
-    receiver.count(:begin_document).should eql(0)
-    receiver.count(:metadata).should eql(1)
+    expect(receiver.count(:begin_document)).to eql(0)
+    expect(receiver.count(:metadata)).to eql(1)
   end
 
 end
@@ -84,11 +84,11 @@ describe PDF::Reader, "object_file class method" do
   end
 
   it "should extract an object from string containing a full PDF file" do
-    PDF::Reader.object_file(@filename, 7, 0).should eql(515)
+    expect(PDF::Reader.object_file(@filename, 7, 0)).to eql(515)
   end
 
   it "should extract an object from string containing a full PDF file" do
-    PDF::Reader.object_file(@filename, 7).should eql(515)
+    expect(PDF::Reader.object_file(@filename, 7)).to eql(515)
   end
 end
 
@@ -97,11 +97,11 @@ describe PDF::Reader, "object_string class method" do
   let(:data) { binread(pdf_spec_file("cairo-unicode-short")) }
 
   it "should extract an object from string containing a full PDF file" do
-    PDF::Reader.object_string(data, 7, 0).should eql(515)
+    expect(PDF::Reader.object_string(data, 7, 0)).to eql(515)
   end
 
   it "should extract an object from string containing a full PDF file" do
-    PDF::Reader.object_string(data, 7).should eql(515)
+    expect(PDF::Reader.object_string(data, 7)).to eql(515)
   end
 
 end

--- a/spec/encoding_spec.rb
+++ b/spec/encoding_spec.rb
@@ -6,15 +6,15 @@ describe PDF::Reader::Encoding, "initialisation" do
 
   context "when the encoding is unrecognised" do
     it "should return a new encoding object" do
-      PDF::Reader::Encoding.new("FakeEncoding").should be_a_kind_of(PDF::Reader::Encoding)
-      PDF::Reader::Encoding.new(nil).should be_a_kind_of(PDF::Reader::Encoding)
+      expect(PDF::Reader::Encoding.new("FakeEncoding")).to be_a_kind_of(PDF::Reader::Encoding)
+      expect(PDF::Reader::Encoding.new(nil)).to be_a_kind_of(PDF::Reader::Encoding)
     end
   end
 
   context "when the encoding is WinAnsi" do
     it "should return a new encoding object" do
       win =  {:Encoding => :WinAnsiEncoding}
-      PDF::Reader::Encoding.new(win).should  be_a_kind_of(PDF::Reader::Encoding)
+      expect(PDF::Reader::Encoding.new(win)).to  be_a_kind_of(PDF::Reader::Encoding)
     end
   end
 
@@ -25,12 +25,12 @@ describe PDF::Reader::Encoding, "initialisation" do
                                )
     end
     it "should return a new encoding object" do
-      enc.should be_a_kind_of(PDF::Reader::Encoding)
+      expect(enc).to be_a_kind_of(PDF::Reader::Encoding)
     end
     it "should record the differences" do
-      enc.differences.should be_a_kind_of(Hash)
-      enc.differences[25].should eql(:A)
-      enc.differences[26].should eql(:B)
+      expect(enc.differences).to be_a_kind_of(Hash)
+      expect(enc.differences[25]).to eql(:A)
+      expect(enc.differences[26]).to eql(:B)
     end
   end
 
@@ -41,12 +41,12 @@ describe PDF::Reader::Encoding, "initialisation" do
                                )
     end
     it "should return a new encoding object" do
-      enc.should be_a_kind_of(PDF::Reader::Encoding)
+      expect(enc).to be_a_kind_of(PDF::Reader::Encoding)
     end
     it "should record the differences" do
-      enc.differences.should be_a_kind_of(Hash)
-      enc.differences[25].should eql(:A)
-      enc.differences[26].should eql(:B)
+      expect(enc.differences).to be_a_kind_of(Hash)
+      expect(enc.differences[25]).to eql(:A)
+      expect(enc.differences[26]).to eql(:B)
     end
   end
 
@@ -61,11 +61,10 @@ describe PDF::Reader::Encoding, "#to_utf8" do
                                )
     end
     it "should convert recognised characters from the differences to utf-8" do
-      pending
-      enc.to_utf8("\001").should eql("A")
+      expect(enc.to_utf8("\001")).to eql("A")
     end
     it "should convert unknown characters with 'unknown char'" do
-      enc.to_utf8("\002").should eql("▯")
+      expect(enc.to_utf8("\002")).to eql("▯")
     end
   end
 
@@ -79,11 +78,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
       ].each do |vals|
         result = e.to_utf8(vals[:expert])
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
       end
     end
   end
@@ -99,11 +98,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:expert])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
       end
     end
   end
@@ -120,11 +119,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:expert])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
       end
     end
   end
@@ -139,11 +138,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:mac])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -162,10 +161,10 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         {:mac => "\xFD", :utf8 => "\xCB\x9D"}      # ˝ sign
       ].each do |vals|
         result = e.to_utf8(vals[:mac])
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
         end
       end
     end
@@ -182,11 +181,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:mac])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -204,11 +203,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:pdf])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
       end
     end
   end
@@ -223,11 +222,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:pdf])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -247,11 +246,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:standard])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -267,11 +266,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:std])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -289,11 +288,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:symbol])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -309,11 +308,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:symbol])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -332,10 +331,10 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         {:win => "\x9F", :utf8 => "\xC5\xB8"}      # Ÿ sign
       ].each do |vals|
         result = e.to_utf8(vals[:win])
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
         end
       end
     end
@@ -351,10 +350,10 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         {:win => "ABC\xEE", :utf8 => "ABCA"}
       ].each do |vals|
         result = e.to_utf8(vals[:win])
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
         end
       end
     end
@@ -371,11 +370,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:dingbats])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -391,11 +390,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:dingbats])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
 
       end
     end
@@ -413,11 +412,11 @@ describe PDF::Reader::Encoding, "#to_utf8" do
         result = e.to_utf8(vals[:utf16])
 
         if RUBY_VERSION >= "1.9"
-          result.encoding.to_s.should eql("UTF-8")
+          expect(result.encoding.to_s).to eql("UTF-8")
           vals[:utf8].force_encoding("UTF-8")
         end
 
-        result.should eql(vals[:utf8])
+        expect(result).to eql(vals[:utf8])
       end
     end
   end
@@ -430,7 +429,7 @@ describe PDF::Reader::Encoding, "#int_to_utf8_string" do
       PDF::Reader::Encoding.new(:Encoding => :WinAnsiEncoding)
     }
     it "should convert a int glyph code to the relevant utf-8 string" do
-      enc.int_to_utf8_string(65).should == "A"
+      expect(enc.int_to_utf8_string(65)).to eq("A")
     end
   end
 end

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -7,69 +7,69 @@ describe PDF::Reader::Filter do
   describe "#with" do
     context "when passed :ASCII85Decode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:ASCII85Decode).should be_a(PDF::Reader::Filter::Ascii85)
+        expect(PDF::Reader::Filter.with(:ASCII85Decode)).to be_a(PDF::Reader::Filter::Ascii85)
       end
     end
 
     context "when passed :ASCIIHexDecode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:ASCIIHexDecode).should be_a(PDF::Reader::Filter::AsciiHex)
+        expect(PDF::Reader::Filter.with(:ASCIIHexDecode)).to be_a(PDF::Reader::Filter::AsciiHex)
       end
     end
 
     context "when passed :CCITTFaxDecode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:CCITTFaxDecode).should be_a(PDF::Reader::Filter::Null)
+        expect(PDF::Reader::Filter.with(:CCITTFaxDecode)).to be_a(PDF::Reader::Filter::Null)
       end
     end
 
     context "when passed :DCTDecode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:DCTDecode).should be_a(PDF::Reader::Filter::Null)
+        expect(PDF::Reader::Filter.with(:DCTDecode)).to be_a(PDF::Reader::Filter::Null)
       end
     end
 
     context "when passed :ASCII85Decode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:ASCII85Decode).should be_a(PDF::Reader::Filter::Ascii85)
+        expect(PDF::Reader::Filter.with(:ASCII85Decode)).to be_a(PDF::Reader::Filter::Ascii85)
       end
     end
 
     context "when passed :FlateDecode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:FlateDecode).should be_a(PDF::Reader::Filter::Flate)
+        expect(PDF::Reader::Filter.with(:FlateDecode)).to be_a(PDF::Reader::Filter::Flate)
       end
     end
 
     context "when passed :JBIG2ecode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:JBIG2Decode).should be_a(PDF::Reader::Filter::Null)
+        expect(PDF::Reader::Filter.with(:JBIG2Decode)).to be_a(PDF::Reader::Filter::Null)
       end
     end
 
     context "when passed :JPXDecode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:JPXDecode).should be_a(PDF::Reader::Filter::Null)
+        expect(PDF::Reader::Filter.with(:JPXDecode)).to be_a(PDF::Reader::Filter::Null)
       end
     end
 
     context "when passed :LZWDecode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:LZWDecode).should be_a(PDF::Reader::Filter::Lzw)
+        expect(PDF::Reader::Filter.with(:LZWDecode)).to be_a(PDF::Reader::Filter::Lzw)
       end
     end
 
     context "when passed :RunLengthDecode" do
       it "should return the appropriate class" do
-        PDF::Reader::Filter.with(:RunLengthDecode).should be_a(PDF::Reader::Filter::RunLength)
+        expect(PDF::Reader::Filter.with(:RunLengthDecode)).to be_a(PDF::Reader::Filter::RunLength)
       end
     end
 
     context "when passed an unrecognised filter" do
       it "should raise an exception" do
-        lambda {
+        expect {
           PDF::Reader::Filter.with(:FooDecode)
-        }.should raise_error(PDF::Reader::UnsupportedFeatureError)
+        }.to raise_error(PDF::Reader::UnsupportedFeatureError)
       end
     end
   end

--- a/spec/font_descriptor_spec.rb
+++ b/spec/font_descriptor_spec.rb
@@ -27,30 +27,30 @@ describe PDF::Reader::FontDescriptor, "initialisation" do
   subject        { PDF::Reader::FontDescriptor.new(objects, dict)}
 
   it "should set the correct instance vars" do
-    subject.ascent.should            == 10
-    subject.descent.should           == 10
-    subject.missing_width.should     == 500
-    subject.font_bounding_box.should == [0,0, 10, 10]
-    subject.avg_width.should         == 40
-    subject.cap_height.should        == 30
-    subject.font_flags.should        == 1
-    subject.italic_angle.should      == 0
-    subject.font_name.should         == "Helvetica"
-    subject.leading.should           == 0
-    subject.max_width.should         == 500
-    subject.stem_v.should            == 0
-    subject.x_height.should          == 0
-    subject.font_stretch.should      == :Condensed
-    subject.font_weight.should       == 500
-    subject.font_family.should       == :BoldItalic
+    expect(subject.ascent).to            eq(10)
+    expect(subject.descent).to           eq(10)
+    expect(subject.missing_width).to     eq(500)
+    expect(subject.font_bounding_box).to eq([0,0, 10, 10])
+    expect(subject.avg_width).to         eq(40)
+    expect(subject.cap_height).to        eq(30)
+    expect(subject.font_flags).to        eq(1)
+    expect(subject.italic_angle).to      eq(0)
+    expect(subject.font_name).to         eq("Helvetica")
+    expect(subject.leading).to           eq(0)
+    expect(subject.max_width).to         eq(500)
+    expect(subject.stem_v).to            eq(0)
+    expect(subject.x_height).to          eq(0)
+    expect(subject.font_stretch).to      eq(:Condensed)
+    expect(subject.font_weight).to       eq(500)
+    expect(subject.font_family).to       eq(:BoldItalic)
   end
 
 end
 
 describe PDF::Reader::FontDescriptor, "#glyph_width" do
-  pending
+  skip
 end
 
 describe PDF::Reader::FontDescriptor, "#glyph_to_pdf_scale_factor" do
-  pending
+  skip
 end

--- a/spec/font_spec.rb
+++ b/spec/font_spec.rb
@@ -12,18 +12,18 @@ describe PDF::Reader::Font do
 
     it "should select a sensible encoding when set to a symbol font" do
       font.basefont = "Arial"
-      font.encoding.should be_a_kind_of(PDF::Reader::Encoding)
+      expect(font.encoding).to be_a_kind_of(PDF::Reader::Encoding)
 
       font.basefont = "Symbol"
-      font.encoding.should be_a_kind_of(PDF::Reader::Encoding)
+      expect(font.encoding).to be_a_kind_of(PDF::Reader::Encoding)
 
       font.basefont = "ZapfDingbats"
-      font.encoding.should be_a_kind_of(PDF::Reader::Encoding)
+      expect(font.encoding).to be_a_kind_of(PDF::Reader::Encoding)
     end
 
     it "should correctly store the font BaseFont" do
       font.basefont = :Helvetica
-      font.basefont.should eql(:Helvetica)
+      expect(font.basefont).to eql(:Helvetica)
     end
 
   end
@@ -33,32 +33,32 @@ describe PDF::Reader::Font do
       let(:font) { PDF::Reader::Font.new(object_hash, {}) }
 
       it "should delegate to an Encoding object to convert strings to utf-8" do
-        encoding = stub
+        encoding = double
         font.encoding = encoding
-        encoding.should_receive(:to_utf8).with("hello")
+        expect(encoding).to receive(:to_utf8).with("hello")
         font.to_utf8("hello")
       end
 
       it "should delegate to an Encoding object to convert arrays of strings to utf-8" do
-        encoding = stub
+        encoding = double
         font.encoding = encoding
-        encoding.should_receive(:to_utf8).with("hello")
-        encoding.should_receive(:to_utf8).with("howdy")
+        expect(encoding).to receive(:to_utf8).with("hello")
+        expect(encoding).to receive(:to_utf8).with("howdy")
         font.to_utf8(["hello", "howdy"])
       end
 
       it "should return the same type when to_utf8 is called with a string or array" do
-        font.to_utf8("abc").should be_a_kind_of(String)
-        font.to_utf8(["abc"]).should be_a_kind_of(Array)
+        expect(font.to_utf8("abc")).to be_a_kind_of(String)
+        expect(font.to_utf8(["abc"])).to be_a_kind_of(Array)
       end
 
       it "should convert integers to a utf-8 string" do
-        font.to_utf8(123).should be_a_kind_of(String)
+        expect(font.to_utf8(123)).to be_a_kind_of(String)
       end
 
       it "should use an encoding of StandardEncoding if none has been specified" do
         str = "abc\xA8"
-        font.to_utf8(str).should eql("abc\xC2\xA4")
+        expect(font.to_utf8(str)).to eql("abc\xC2\xA4")
       end
     end
 
@@ -66,24 +66,24 @@ describe PDF::Reader::Font do
       let(:font) { PDF::Reader::Font.new(object_hash, {}) }
 
       it "should delegate to a CMap object to convert strings to utf-8" do
-        cmap = stub
-        cmap.should_receive(:decode).with(104).and_return(104)
-        cmap.should_receive(:decode).with(101).and_return(104)
-        cmap.should_receive(:decode).with(108).and_return(104)
-        cmap.should_receive(:decode).with(108).and_return(104)
-        cmap.should_receive(:decode).with(111).and_return(104)
+        cmap = double
+        expect(cmap).to receive(:decode).with(104).and_return(104)
+        expect(cmap).to receive(:decode).with(101).and_return(104)
+        expect(cmap).to receive(:decode).with(108).and_return(104)
+        expect(cmap).to receive(:decode).with(108).and_return(104)
+        expect(cmap).to receive(:decode).with(111).and_return(104)
         font.tounicode = cmap
 
         font.to_utf8("hello")
       end
 
       it "should not delegate to an Encoding object to convert strings to utf-8" do
-        encoding = stub
-        encoding.should_not_receive(:to_utf8)
-        encoding.should_receive(:unpack).and_return("C*")
+        encoding = double
+        expect(encoding).not_to receive(:to_utf8)
+        expect(encoding).to receive(:unpack).and_return("C*")
         font.encoding = encoding
-        cmap = stub
-        cmap.should_receive(:decode).exactly(5).times.and_return(104)
+        cmap = double
+        expect(cmap).to receive(:decode).exactly(5).times.and_return(104)
         font.tounicode = cmap
 
         font.to_utf8("hello")
@@ -102,7 +102,7 @@ describe PDF::Reader::Font do
       let(:font) { PDF::Reader::Font.new(object_hash, raw) }
 
       it "should unpack a binary string into ints" do
-        font.unpack("\x41\x42").should == [65,66]
+        expect(font.unpack("\x41\x42")).to eq([65,66])
       end
     end
   end
@@ -120,11 +120,11 @@ describe PDF::Reader::Font do
       let(:font) { PDF::Reader::Font.new(object_hash, raw) }
 
       it "should return the width for a glyph" do
-        font.glyph_width(2).should == 200
+        expect(font.glyph_width(2)).to eq(200)
       end
 
       it "should return 0 for an unknown glyph" do
-        font.glyph_width(10).should == 0
+        expect(font.glyph_width(10)).to eq(0)
       end
     end
 
@@ -140,11 +140,11 @@ describe PDF::Reader::Font do
       let(:font) { PDF::Reader::Font.new(object_hash, raw) }
 
       it "should return the width for a glyph" do
-        font.glyph_width(7).should == 300
+        expect(font.glyph_width(7)).to eq(300)
       end
 
       it "should return 0 for an unknown glyph" do
-        font.glyph_width(20).should == 0
+        expect(font.glyph_width(20)).to eq(0)
       end
     end
   end

--- a/spec/glyph_hash_spec.rb
+++ b/spec/glyph_hash_spec.rb
@@ -6,51 +6,51 @@ describe PDF::Reader::GlyphHash, "#name_to_unicode" do
 
   it "should correctly map a standard glyph name to unicode" do
     map = PDF::Reader::GlyphHash.new
-    map.name_to_unicode(:a).should eql(0x0061)
-    map.name_to_unicode(:e).should eql(0x0065)
-    map.name_to_unicode(:A).should eql(0x0041)
-    map.name_to_unicode(:holam).should eql(0x05B9)
-    map.name_to_unicode(:zukatakana).should eql(0x30BA)
+    expect(map.name_to_unicode(:a)).to eql(0x0061)
+    expect(map.name_to_unicode(:e)).to eql(0x0065)
+    expect(map.name_to_unicode(:A)).to eql(0x0041)
+    expect(map.name_to_unicode(:holam)).to eql(0x05B9)
+    expect(map.name_to_unicode(:zukatakana)).to eql(0x30BA)
   end
 
   it "should correctly map a glyph name with underscores to unicode" do
     map = PDF::Reader::GlyphHash.new
-    map.name_to_unicode(:f_i).should eql(map.name_to_unicode(:fi))
+    expect(map.name_to_unicode(:f_i)).to eql(map.name_to_unicode(:fi))
   end
 
   it "should correctly map a uniHHHH glyph to unicode" do
     map = PDF::Reader::GlyphHash.new
-    map.name_to_unicode(:uni0032).should eql(0x0032)
-    map.name_to_unicode(:uni1234).should eql(0x1234)
+    expect(map.name_to_unicode(:uni0032)).to eql(0x0032)
+    expect(map.name_to_unicode(:uni1234)).to eql(0x1234)
   end
 
   it "should correctly map a uHHHH glyph to unicode" do
     map = PDF::Reader::GlyphHash.new
-    map.name_to_unicode(:u0032).should   eql(0x0032)
-    map.name_to_unicode(:u1234).should   eql(0x1234)
-    map.name_to_unicode(:u12345).should  eql(0x12345)
-    map.name_to_unicode(:u123456).should eql(0x123456)
+    expect(map.name_to_unicode(:u0032)).to   eql(0x0032)
+    expect(map.name_to_unicode(:u1234)).to   eql(0x1234)
+    expect(map.name_to_unicode(:u12345)).to  eql(0x12345)
+    expect(map.name_to_unicode(:u123456)).to eql(0x123456)
   end
 
   it "should correctly map a Ann glyph to unicode" do
     map = PDF::Reader::GlyphHash.new
-    map.name_to_unicode(:A65).should     eql(65)
-    map.name_to_unicode(:g3).should      eql(3)
-    map.name_to_unicode(:g65).should     eql(65)
-    map.name_to_unicode(:G65).should     eql(65)
-    map.name_to_unicode(:G655).should    eql(655)
-    map.name_to_unicode(:G6555).should   eql(6555)
-    map.name_to_unicode(:G20000).should  eql(20000)
+    expect(map.name_to_unicode(:A65)).to     eql(65)
+    expect(map.name_to_unicode(:g3)).to      eql(3)
+    expect(map.name_to_unicode(:g65)).to     eql(65)
+    expect(map.name_to_unicode(:G65)).to     eql(65)
+    expect(map.name_to_unicode(:G655)).to    eql(655)
+    expect(map.name_to_unicode(:G6555)).to   eql(6555)
+    expect(map.name_to_unicode(:G20000)).to  eql(20000)
   end
 
   it "should correctly map a AAnn glyph to unicode" do
     map = PDF::Reader::GlyphHash.new
-    map.name_to_unicode(:AA65).should     eql(65)
-    map.name_to_unicode(:gg65).should     eql(65)
-    map.name_to_unicode(:GG65).should     eql(65)
-    map.name_to_unicode(:GG655).should    eql(655)
-    map.name_to_unicode(:GG6555).should   eql(6555)
-    map.name_to_unicode(:GG20000).should eql(20000)
+    expect(map.name_to_unicode(:AA65)).to     eql(65)
+    expect(map.name_to_unicode(:gg65)).to     eql(65)
+    expect(map.name_to_unicode(:GG65)).to     eql(65)
+    expect(map.name_to_unicode(:GG655)).to    eql(655)
+    expect(map.name_to_unicode(:GG6555)).to   eql(6555)
+    expect(map.name_to_unicode(:GG20000)).to eql(20000)
   end
 
 end
@@ -59,15 +59,15 @@ describe PDF::Reader::GlyphHash, "#unicode_to_name" do
 
   it "should correctly map a standard glyph name to unicode" do
     map = PDF::Reader::GlyphHash.new
-    map.unicode_to_name(0x0061).should eql([:a])
-    map.unicode_to_name(0x0065).should eql([:e])
-    map.unicode_to_name(0x0041).should eql([:A])
-    map.unicode_to_name(0x05B9).should eql(
+    expect(map.unicode_to_name(0x0061)).to eql([:a])
+    expect(map.unicode_to_name(0x0065)).to eql([:e])
+    expect(map.unicode_to_name(0x0041)).to eql([:A])
+    expect(map.unicode_to_name(0x05B9)).to eql(
       [:afii57806, :holam, :holam19, :holam26,
       :holam32, :holamhebrew, :holamnarrowhebrew,
       :holamquarterhebrew, :holamwidehebrew]
     )
-    map.unicode_to_name(0x20AC).should eql([:Euro, :euro])
-    map.unicode_to_name(0x30BA).should eql([:zukatakana])
+    expect(map.unicode_to_name(0x20AC)).to eql([:Euro, :euro])
+    expect(map.unicode_to_name(0x30BA)).to eql([:zukatakana])
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -17,7 +17,7 @@ describe PDF::Reader, "integration specs" do
 
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should eql("Chunky Bacon")
+      expect(page.text).to eql("Chunky Bacon")
     end
   end
 
@@ -26,7 +26,7 @@ describe PDF::Reader, "integration specs" do
 
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.split.map(&:strip).should eql(%w{V e r t i c a l T e x t})
+      expect(page.text.split.map(&:strip)).to eql(%w{V e r t i c a l T e x t})
     end
   end
 
@@ -35,8 +35,8 @@ describe PDF::Reader, "integration specs" do
 
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should include("This is a sample PDF file")
-      page.text.should include("If you can read this, you already have Adobe Acrobat")
+      expect(page.text).to include("This is a sample PDF file")
+      expect(page.text).to include("If you can read this, you already have Adobe Acrobat")
     end
   end
 
@@ -44,12 +44,12 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("dutch")
 
     PDF::Reader.open(filename) do |reader|
-      reader.pages.size.should eql(3)
+      expect(reader.pages.size).to eql(3)
 
       page = reader.page(1)
-      page.text.should include("Dit\302\240is\302\240een\302\240pdf\302\240test\302\240van\302\240drie\302\240pagina")
-      page.text.should include("’s")
-      page.text.should include("Pagina\302\2401")
+      expect(page.text).to include("Dit\302\240is\302\240een\302\240pdf\302\240test\302\240van\302\240drie\302\240pagina")
+      expect(page.text).to include("’s")
+      expect(page.text).to include("Pagina\302\2401")
     end
   end
 
@@ -58,7 +58,7 @@ describe PDF::Reader, "integration specs" do
 
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should eql("Goiás")
+      expect(page.text).to eql("Goiás")
     end
   end
 
@@ -67,7 +67,7 @@ describe PDF::Reader, "integration specs" do
 
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should match(/Tax\s+Invoice/)
+      expect(page.text).to match(/Tax\s+Invoice/)
     end
   end
 
@@ -75,8 +75,8 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("content_stream_missing_final_operator")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should match(/Locatrix/)
-      reader.page(2).text.should match(/Ubuntu/)
+      expect(reader.page(1).text).to match(/Locatrix/)
+      expect(reader.page(2).text).to match(/Ubuntu/)
     end
   end
 
@@ -87,9 +87,9 @@ describe PDF::Reader, "integration specs" do
 
     PDF::Reader.open(filename) do |reader|
       if RUBY_VERSION >= "1.9"
-        reader.page(1).text[0,1].should eql("’")
+        expect(reader.page(1).text[0,1]).to eql("’")
       else
-        reader.page(1).text[0,3].should eql("’")
+        expect(reader.page(1).text[0,3]).to eql("’")
       end
     end
   end
@@ -99,10 +99,10 @@ describe PDF::Reader, "integration specs" do
 
     # this file used to get us into a hard, endless loop. Make sure that doesn't still happen
     Timeout::timeout(3) do
-      lambda {
+      expect {
         reader = PDF::Reader.new(filename)
         reader.info
-      }.should raise_error(PDF::Reader::MalformedPDFError)
+      }.to raise_error(PDF::Reader::MalformedPDFError)
     end
   end
 
@@ -110,7 +110,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("content_stream_with_length_as_ref")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should eql("Hello World")
+      expect(reader.page(1).text).to eql("Hello World")
     end
   end
 
@@ -121,30 +121,30 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("content_stream_with_length_as_ref_and_windows_breaks")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should eql("Hello World")
+      expect(reader.page(1).text).to eql("Hello World")
     end
   end
 
   it "should raise an exception if a content stream refers to a non-existant font" do
     filename = pdf_spec_file("content_stream_refers_to_invalid_font")
 
-    lambda {
+    expect {
       reader = PDF::Reader.new(filename)
       reader.page(1).text
-    }.should raise_error(PDF::Reader::MalformedPDFError)
+    }.to raise_error(PDF::Reader::MalformedPDFError)
   end
 
   it "should raise an exception if the file is empty" do
-    lambda {
+    expect {
       PDF::Reader.new(StringIO.new(""))
-    }.should raise_error(PDF::Reader::MalformedPDFError)
+    }.to raise_error(PDF::Reader::MalformedPDFError)
   end
 
   it "should correctly process a PDF that uses an ASCII85Decode filter" do
     filename = pdf_spec_file("ascii85_filter")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should match(/Et Iunia se/)
+      expect(reader.page(1).text).to match(/Et Iunia se/)
     end
   end
 
@@ -152,7 +152,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("inline_image_single_line_content_stream")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.strip[0,7].should eql("WORKING")
+      expect(reader.page(1).text.strip[0,7]).to eql("WORKING")
     end
   end
 
@@ -160,8 +160,8 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("form_xobject")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should eql("James Healy")
-      reader.page(2).text.should eql("James Healy")
+      expect(reader.page(1).text).to eql("James Healy")
+      expect(reader.page(2).text).to eql("James Healy")
     end
   end
 
@@ -169,10 +169,10 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("form_xobject_more")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should include("Some regular content")
-      reader.page(1).text.should include("James Healy")
-      reader.page(2).text.should include("€10")
-      reader.page(2).text.should include("James Healy")
+      expect(reader.page(1).text).to include("Some regular content")
+      expect(reader.page(1).text).to include("James Healy")
+      expect(reader.page(2).text).to include("€10")
+      expect(reader.page(2).text).to include("James Healy")
     end
   end
 
@@ -180,7 +180,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("indirect_xobject")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should_not be_nil
+      expect(reader.page(1).text).not_to be_nil
     end
   end
 
@@ -188,8 +188,8 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("split_params_and_operator")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should include("My name is")
-      reader.page(1).text.should include("James Healy")
+      expect(reader.page(1).text).to include("My name is")
+      expect(reader.page(1).text).to include("James Healy")
     end
   end
 
@@ -197,7 +197,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("space_after_eof")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should eql("Hello World")
+      expect(reader.page(1).text).to eql("Hello World")
     end
   end
 
@@ -205,7 +205,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("oo3")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should include("test")
+      expect(reader.page(1).text).to include("test")
     end
   end
 
@@ -213,7 +213,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("content_stream_begins_with_newline")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should eql("This file has a content stream that begins with \\n\\n")
+      expect(reader.page(1).text).to eql("This file has a content stream that begins with \\n\\n")
     end
   end
 
@@ -221,7 +221,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("encrypted_no_user_pass")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should eql("This sample file is encrypted with no user password")
+      expect(reader.page(1).text).to eql("This sample file is encrypted with no user password")
     end
   end
 
@@ -229,7 +229,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("encrypted_with_no_user_pass_and_revision_one")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should eql("WOOOOO DOCUMENT!")
+      expect(reader.page(1).text).to eql("WOOOOO DOCUMENT!")
     end
   end
 
@@ -237,9 +237,9 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("encrypted_with_user_pass_apples")
 
     PDF::Reader.open(filename, :password => "apples") do |reader|
-      reader.page(1).text.should match(/^This sample file is encrypted with a user password.$/m)
-      reader.page(1).text.should match(/^User password: apples$/m)
-      reader.page(1).text.should match(/^Owner password: password$/m)
+      expect(reader.page(1).text).to match(/^This sample file is encrypted with a user password.$/m)
+      expect(reader.page(1).text).to match(/^User password: apples$/m)
+      expect(reader.page(1).text).to match(/^Owner password: password$/m)
     end
   end
 
@@ -247,27 +247,27 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("encrypted_with_user_pass_apples")
 
     PDF::Reader.open(filename, :password => "password") do |reader|
-      reader.page(1).text.should match(/^This sample file is encrypted with a user password.$/)
-      reader.page(1).text.should match(/^User password: apples$/m)
-      reader.page(1).text.should match(/^Owner password: password$/m)
+      expect(reader.page(1).text).to match(/^This sample file is encrypted with a user password.$/)
+      expect(reader.page(1).text).to match(/^User password: apples$/m)
+      expect(reader.page(1).text).to match(/^Owner password: password$/m)
     end
   end
 
   it "should raise an exception from an encrypted PDF that requires a user password and none is provided" do
     filename = pdf_spec_file("encrypted_with_user_pass_apples")
 
-    lambda {
+    expect {
       PDF::Reader.open(filename) do |reader|
         reader.page(1).text
       end
-    }.should raise_error(PDF::Reader::EncryptedPDFError)
+    }.to raise_error(PDF::Reader::EncryptedPDFError)
   end
 
   it "should correctly extract text from an encrypted PDF with no user pass or document ID" do
     filename = pdf_spec_file("encrypted_with_no_doc_id")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should eql(
+      expect(reader.page(1).text).to eql(
         "This encryped file breaks compatability with the PDF spec because it has no document ID"
       )
     end
@@ -283,26 +283,26 @@ describe PDF::Reader, "integration specs" do
     callbacks = receiver.series(:begin_inline_image, :begin_inline_image_data, :end_inline_image)
 
     # inline images should trigger 3 callbacks. The first with no args.
-    callbacks[0].should eql(:name => :begin_inline_image, :args => [])
+    expect(callbacks[0]).to eql(:name => :begin_inline_image, :args => [])
 
     # the second with the image header (colorspace, etc)
-    callbacks[1].should eql(:name => :begin_inline_image_data, :args => [:CS, :RGB, :I, true, :W, 234, :H, 70, :BPC, 8])
+    expect(callbacks[1]).to eql(:name => :begin_inline_image_data, :args => [:CS, :RGB, :I, true, :W, 234, :H, 70, :BPC, 8])
 
     # the last with the image data
-    callbacks[2][:name].should eql :end_inline_image
+    expect(callbacks[2][:name]).to eql :end_inline_image
     image_data =  callbacks[2][:args].first
 
-    image_data.should be_a(String)
-    image_data.size.should  eql 49140
-    image_data[0,3].unpack("C*").should   eql [255,255,255]
-    image_data[-3,3].unpack("C*").should  eql [255,255,255]
+    expect(image_data).to be_a(String)
+    expect(image_data.size).to  eql 49140
+    expect(image_data[0,3].unpack("C*")).to   eql [255,255,255]
+    expect(image_data[-3,3].unpack("C*")).to  eql [255,255,255]
   end
 
   it "should correctly extract text from a page that has multiple content streams" do
     filename = pdf_spec_file("content_stream_as_array")
 
     PDF::Reader.open(filename) do |reader|
-      reader.page(1).text.should include("Arkansas Declaration Relating")
+      expect(reader.page(1).text).to include("Arkansas Declaration Relating")
     end
   end
 
@@ -311,7 +311,7 @@ describe PDF::Reader, "integration specs" do
 
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should eql("This PDF contains junk before the %-PDF marker")
+      expect(page.text).to eql("This PDF contains junk before the %-PDF marker")
     end
   end
 
@@ -328,7 +328,7 @@ describe PDF::Reader, "integration specs" do
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
       m = /raffic/.match(page.text)
-      m[0].to_s.should eql("raffic")
+      expect(m[0].to_s).to eql("raffic")
     end
   end
 
@@ -347,7 +347,7 @@ describe PDF::Reader, "integration specs" do
       page = reader.page(1)
       # 𝑵𝑨𝑺𝑪𝑨𝑹
       utf8_str = [0x1d475, 0x1d468, 0x1d47a, 0x1d46a, 0x1d468, 0x1d479].pack("U*")
-      page.text.should include(utf8_str)
+      expect(page.text).to include(utf8_str)
     end
   end
 
@@ -355,7 +355,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("standard_font_with_a_difference")
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should == "The following word uses a ligature: ﬁve"
+      expect(page.text).to eq("The following word uses a ligature: ﬁve")
     end
   end
 
@@ -366,7 +366,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("rotated_text")
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.split("\n").map(&:strip).slice(0,2).should == ["°","9"]
+      expect(page.text.split("\n").map(&:strip).slice(0,2)).to eq(["°","9"])
     end
   end
 
@@ -374,7 +374,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("TJ_starts_with_a_number")
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text[0,18].should == "This file has a TJ"
+      expect(page.text[0,18]).to eq("This file has a TJ")
     end
   end
 
@@ -382,7 +382,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("mediabox_missing")
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text[0,54].should == "This page is missing the compulsory MediaBox attribute"
+      expect(page.text[0,54]).to eq("This page is missing the compulsory MediaBox attribute")
     end
   end
 
@@ -390,7 +390,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("standard_font_with_no_difference")
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should == "This page uses contains a €"
+      expect(page.text).to eq("This page uses contains a €")
     end
   end
 
@@ -398,7 +398,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("zapf")
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should include("✄☎✇")
+      expect(page.text).to include("✄☎✇")
     end
   end
 
@@ -406,7 +406,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("symbol")
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should include("θρ")
+      expect(page.text).to include("θρ")
     end
   end
 
@@ -414,7 +414,7 @@ describe PDF::Reader, "integration specs" do
     filename = pdf_spec_file("times-with-control-character")
     PDF::Reader.open(filename) do |reader|
       page = reader.page(1)
-      page.text.should include("This text includes an ASCII control")
+      expect(page.text).to include("This text includes an ASCII control")
     end
   end
 end

--- a/spec/integrity_spec.rb
+++ b/spec/integrity_spec.rb
@@ -24,14 +24,14 @@ describe "Spec suite PDFs" do
       item = integrity[relative_path]
 
       # every PDF in the suite MUST be included in the integrity file
-      item.should_not be_nil, "#{path} not found in integrity YAML file"
+      expect(item).not_to be_nil, "#{path} not found in integrity YAML file"
 
       # every PDF in the suite MUST be the correct number of bytes
-      File.size(path).should eql(item[:bytes])
+      expect(File.size(path)).to eql(item[:bytes])
 
       # every PDF in the suite MUST be unchanged
       md5 = Digest::MD5.hexdigest(File.open(path, "rb") { |f|  f.read })
-      md5.should == item[:md5]
+      expect(md5).to eq(item[:md5])
     end
   end
 end

--- a/spec/lzw_spec.rb
+++ b/spec/lzw_spec.rb
@@ -8,12 +8,12 @@ describe PDF::Reader::LZW do
       byte.to_i(16)
     }.pack("C*")
 
-    PDF::Reader::LZW.decode(content).should == '-----A---B'
+    expect(PDF::Reader::LZW.decode(content)).to eq('-----A---B')
   end
 
   it "should correctly decode another lzw compressed string" do
     content = binread(File.dirname(__FILE__) + "/data/lzw_compressed2.dat")
 
-    PDF::Reader::LZW.decode(content).should match(/\ABT/)
+    expect(PDF::Reader::LZW.decode(content)).to match(/\ABT/)
   end
 end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -16,7 +16,7 @@ describe PDF::Reader::MetadataStrategy do
     meta = cb[:args].first
 
     # check the metadata was extracted correctly
-    meta[:Producer].should eql("YesLogic Prince 5.1")
+    expect(meta[:Producer]).to eql("YesLogic Prince 5.1")
   end
 
   it "should send the correct metadata callbacks when processing an openoffice PDF" do
@@ -30,9 +30,9 @@ describe PDF::Reader::MetadataStrategy do
     meta = cb[:args].first
 
     # check the metadata was extracted correctly
-    meta[:Creator].should eql("Writer")
-    meta[:Producer].should eql("OpenOffice.org 2.2")
-    meta[:CreationDate].should eql("D:20070623021705+10'00'")
+    expect(meta[:Creator]).to eql("Writer")
+    expect(meta[:Producer]).to eql("OpenOffice.org 2.2")
+    expect(meta[:CreationDate]).to eql("D:20070623021705+10'00'")
   end
 
   it "should send the correct xml_metadata callbacks when processing a distiller PDF" do
@@ -46,7 +46,7 @@ describe PDF::Reader::MetadataStrategy do
     meta = cb[:args].first
 
     # check the metadata was extracted correctly
-    meta.include?("<pdf:Title>file://C:\\Data\\website\\i18nguy\\unicode-example.html</pdf:Title>").should be_true
+    expect(meta.include?("<pdf:Title>file://C:\\Data\\website\\i18nguy\\unicode-example.html</pdf:Title>")).to be_truthy
   end
 
   it "should send the correct page count callback when processing an openoffice PDF" do
@@ -57,7 +57,7 @@ describe PDF::Reader::MetadataStrategy do
     filename = pdf_spec_file("openoffice-2.2")
     PDF::Reader.file(filename, receiver, :pages => false)
     cb = receiver.first_occurance_of(:page_count)
-    cb[:args].first.should eql(2)
+    expect(cb[:args].first).to eql(2)
   end
 
   it "should send the correct pdf_version callback when processing an openoffice PDF" do
@@ -68,6 +68,6 @@ describe PDF::Reader::MetadataStrategy do
     filename = pdf_spec_file("openoffice-2.2")
     PDF::Reader.file(filename, receiver, :pages => false)
     cb = receiver.first_occurance_of(:pdf_version)
-    cb[:args].first.should eql(1.4)
+    expect(cb[:args].first).to eql(1.4)
   end
 end

--- a/spec/object_hash_spec.rb
+++ b/spec/object_hash_spec.rb
@@ -7,7 +7,7 @@ describe PDF::Reader::ObjectHash do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.map { |ref, obj| obj.class }.size.should eql(57)
+    expect(h.map { |ref, obj| obj.class }.size).to eql(57)
   end
 end
 
@@ -17,12 +17,12 @@ describe PDF::Reader::ObjectHash do
     io = StringIO.new(binread(filename))
     h = PDF::Reader::ObjectHash.new(io)
 
-    h.map { |ref, obj| obj.class }.size.should eql(57)
+    expect(h.map { |ref, obj| obj.class }.size).to eql(57)
   end
 
   it "should raise an ArgumentError if passed a non filename and non IO" do
     filename = pdf_spec_file("cairo-unicode")
-     lambda {PDF::Reader::ObjectHash.new(10)}.should raise_error(ArgumentError)
+     expect {PDF::Reader::ObjectHash.new(10)}.to raise_error(ArgumentError)
   end
 
 end
@@ -33,25 +33,25 @@ describe PDF::Reader::ObjectHash, "[] method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h[-1].should be_nil
-    h[nil].should be_nil
-    h["James"].should be_nil
+    expect(h[-1]).to be_nil
+    expect(h[nil]).to be_nil
+    expect(h["James"]).to be_nil
   end
 
   it "should return nil for any hash key that doesn't exist" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h[10000].should be_nil
+    expect(h[10000]).to be_nil
   end
 
   it "should correctly extract an int object using int or string keys" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h[3].should eql(3649)
-    h["3"].should eql(3649)
-    h["3james"].should eql(3649)
+    expect(h[3]).to eql(3649)
+    expect(h["3"]).to eql(3649)
+    expect(h["3james"]).to eql(3649)
   end
 
   it "should correctly extract an int object using PDF::Reference as a key" do
@@ -59,7 +59,7 @@ describe PDF::Reader::ObjectHash, "[] method" do
     h = PDF::Reader::ObjectHash.new(filename)
     ref = PDF::Reader::Reference.new(3,0)
 
-    h[ref].should eql(3649)
+    expect(h[ref]).to eql(3649)
   end
 end
 
@@ -69,16 +69,16 @@ describe PDF::Reader::ObjectHash, "object method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.object(-1).should      eql(-1)
-    h.object(nil).should     be_nil
-    h.object("James").should eql("James")
+    expect(h.object(-1)).to      eql(-1)
+    expect(h.object(nil)).to     be_nil
+    expect(h.object("James")).to eql("James")
   end
 
   it "should translate reference objects into an extracted PDF object" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.object(PDF::Reader::Reference.new(3,0)).should eql(3649)
+    expect(h.object(PDF::Reader::Reference.new(3,0))).to eql(3649)
   end
 end
 
@@ -89,43 +89,43 @@ describe PDF::Reader::ObjectHash, "deref! method" do
   end
 
   it "should return regular objects unchanged" do
-    hash.deref!(-1).should      eql(-1)
-    hash.deref!(nil).should     be_nil
-    hash.deref!("James").should eql("James")
+    expect(hash.deref!(-1)).to      eql(-1)
+    expect(hash.deref!(nil)).to     be_nil
+    expect(hash.deref!("James")).to eql("James")
   end
 
   it "should translate reference objects into an extracted PDF object" do
-    hash.deref!(PDF::Reader::Reference.new(3,0)).should eq 3649
+    expect(hash.deref!(PDF::Reader::Reference.new(3,0))).to eq 3649
   end
 
   it "should recursively dereference references within hashes" do
     font_descriptor = hash.deref! PDF::Reader::Reference.new(17, 0)
-    font_descriptor[:FontFile3].should be_an_instance_of \
+    expect(font_descriptor[:FontFile3]).to be_an_instance_of \
       PDF::Reader::Stream
   end
 
   it "should recursively dereference references within stream hashes" do
     font_file = hash.deref! PDF::Reader::Reference.new(15, 0)
-    font_file.hash[:Length].should eq 2103
+    expect(font_file.hash[:Length]).to eq 2103
   end
 
   it "should recursively dereference references within arrays" do
     font = hash.deref! PDF::Reader::Reference.new(19, 0)
-    font[:DescendantFonts][0][:Subtype].should eq :CIDFontType0
+    expect(font[:DescendantFonts][0][:Subtype]).to eq :CIDFontType0
   end
 
   it "should return a new Hash, not mutate the provided Hash" do
     orig_collection = {}
     new_collection  = hash.deref!(orig_collection)
 
-    orig_collection.object_id.should_not == new_collection.object_id
+    expect(orig_collection.object_id).not_to eq(new_collection.object_id)
   end
 
   it "should return a new Array, not mutate the provided Array" do
     orig_collection = []
     new_collection  = hash.deref!(orig_collection)
 
-    orig_collection.object_id.should_not == new_collection.object_id
+    expect(orig_collection.object_id).not_to eq(new_collection.object_id)
   end
 
 end
@@ -136,25 +136,25 @@ describe PDF::Reader::ObjectHash, "fetch method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    lambda { h.fetch(-1) }.should raise_error(IndexError)
-    lambda { h.fetch(nil) }.should raise_error(IndexError)
-    lambda { h.fetch("James") }.should raise_error(IndexError)
+    expect { h.fetch(-1) }.to raise_error(IndexError)
+    expect { h.fetch(nil) }.to raise_error(IndexError)
+    expect { h.fetch("James") }.to raise_error(IndexError)
   end
 
   it "should return default for any hash key that doesn't exist when a default is provided" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.fetch(10000, "default").should eql("default")
+    expect(h.fetch(10000, "default")).to eql("default")
   end
 
   it "should correctly extract an int object using int or string keys" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.fetch(3).should eql(3649)
-    h.fetch("3").should eql(3649)
-    h.fetch("3james").should eql(3649)
+    expect(h.fetch(3)).to eql(3649)
+    expect(h.fetch("3")).to eql(3649)
+    expect(h.fetch("3james")).to eql(3649)
   end
 
   it "should correctly extract an int object using PDF::Reader::Reference keys" do
@@ -162,7 +162,7 @@ describe PDF::Reader::ObjectHash, "fetch method" do
     h = PDF::Reader::ObjectHash.new(filename)
     ref = PDF::Reader::Reference.new(3,0)
 
-    h.fetch(ref).should eql(3649)
+    expect(h.fetch(ref)).to eql(3649)
   end
 end
 
@@ -176,7 +176,7 @@ describe PDF::Reader::ObjectHash, "each method" do
     h.each do
       count += 1
     end
-    count.should eql(57)
+    expect(count).to eql(57)
   end
 
   it "should provide a PDF::Reader::Reference to each iteration" do
@@ -184,8 +184,8 @@ describe PDF::Reader::ObjectHash, "each method" do
     h = PDF::Reader::ObjectHash.new(filename)
 
     h.each do |id, obj|
-      id.should be_a_kind_of(PDF::Reader::Reference)
-      obj.should_not be_nil
+      expect(id).to be_a_kind_of(PDF::Reader::Reference)
+      expect(obj).not_to be_nil
     end
   end
 end
@@ -200,7 +200,7 @@ describe PDF::Reader::ObjectHash, "each_key method" do
     h.each_key do
       count += 1
     end
-    count.should eql(57)
+    expect(count).to eql(57)
   end
 
   it "should provide a PDF::Reader::Reference to each iteration" do
@@ -208,7 +208,7 @@ describe PDF::Reader::ObjectHash, "each_key method" do
     h = PDF::Reader::ObjectHash.new(filename)
 
     h.each_key do |ref|
-      ref.should be_a_kind_of(PDF::Reader::Reference)
+      expect(ref).to be_a_kind_of(PDF::Reader::Reference)
     end
   end
 end
@@ -223,7 +223,7 @@ describe PDF::Reader::ObjectHash, "each_value method" do
     h.each_value do
       count += 1
     end
-    count.should eql(57)
+    expect(count).to eql(57)
   end
 end
 
@@ -233,7 +233,7 @@ describe PDF::Reader::ObjectHash, "size method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.size.should eql(57)
+    expect(h.size).to eql(57)
   end
 end
 
@@ -243,7 +243,7 @@ describe PDF::Reader::ObjectHash, "empty? method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.empty?.should be_false
+    expect(h.empty?).to be_falsey
   end
 end
 
@@ -253,18 +253,18 @@ describe PDF::Reader::ObjectHash, "has_key? method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.has_key?(1).should be_true
-    h.has_key?(PDF::Reader::Reference.new(1,0)).should be_true
+    expect(h.has_key?(1)).to be_truthy
+    expect(h.has_key?(PDF::Reader::Reference.new(1,0))).to be_truthy
   end
 
   it "should return false when called with an invalid ID" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.has_key?(-1).should be_false
-    h.has_key?(nil).should be_false
-    h.has_key?("James").should be_false
-    h.has_key?(PDF::Reader::Reference.new(10000,0)).should be_false
+    expect(h.has_key?(-1)).to be_falsey
+    expect(h.has_key?(nil)).to be_falsey
+    expect(h.has_key?("James")).to be_falsey
+    expect(h.has_key?(PDF::Reader::Reference.new(10000,0))).to be_falsey
   end
 end
 
@@ -274,16 +274,16 @@ describe PDF::Reader::ObjectHash, "has_value? method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.has_value?(3649).should be_true
+    expect(h.has_value?(3649)).to be_truthy
   end
 
   it "should return false when called with an invalid object" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.has_value?(-1).should be_false
-    h.has_value?(nil).should be_false
-    h.has_value?("James").should be_false
+    expect(h.has_value?(-1)).to be_falsey
+    expect(h.has_value?(nil)).to be_falsey
+    expect(h.has_value?("James")).to be_falsey
   end
 end
 
@@ -294,8 +294,8 @@ describe PDF::Reader::ObjectHash, "keys method" do
     h = PDF::Reader::ObjectHash.new(filename)
 
     keys = h.keys
-    keys.size.should eql(57)
-    keys.each { |k| k.should be_a_kind_of(PDF::Reader::Reference) }
+    expect(keys.size).to eql(57)
+    keys.each { |k| expect(k).to be_a_kind_of(PDF::Reader::Reference) }
   end
 end
 
@@ -306,8 +306,8 @@ describe PDF::Reader::ObjectHash, "values method" do
     h = PDF::Reader::ObjectHash.new(filename)
 
     values = h.values
-    values.size.should eql(57)
-    values.each { |v| v.should_not be_nil }
+    expect(values.size).to eql(57)
+    values.each { |v| expect(v).not_to be_nil }
   end
 end
 
@@ -319,8 +319,8 @@ describe PDF::Reader::ObjectHash, "values_at method" do
     ref3 = PDF::Reader::Reference.new(3,0)
     ref6 = PDF::Reader::Reference.new(6,0)
 
-    h.values_at(3,6).should eql([3649,3287])
-    h.values_at(ref3,ref6).should eql([3649,3287])
+    expect(h.values_at(3,6)).to eql([3649,3287])
+    expect(h.values_at(ref3,ref6)).to eql([3649,3287])
   end
 end
 
@@ -331,8 +331,8 @@ describe PDF::Reader::ObjectHash, "to_a method" do
     h = PDF::Reader::ObjectHash.new(filename)
 
     arr = h.to_a
-    arr.size.should eql(57)
-    arr.each { |a| a.should be_a_kind_of(Array) }
+    expect(arr.size).to eql(57)
+    arr.each { |a| expect(a).to be_a_kind_of(Array) }
   end
 end
 
@@ -345,9 +345,9 @@ describe PDF::Reader::ObjectHash, "trailer method" do
     expected = {:Size => 58,
                 :Root => PDF::Reader::Reference.new(57,0),
                 :Info => PDF::Reader::Reference.new(56,0)}
-    h.trailer[:Size].should eql(58)
-    h.trailer[:Root].should eql(PDF::Reader::Reference.new(57,0))
-    h.trailer[:Info].should eql(PDF::Reader::Reference.new(56,0))
+    expect(h.trailer[:Size]).to eql(58)
+    expect(h.trailer[:Root]).to eql(PDF::Reader::Reference.new(57,0))
+    expect(h.trailer[:Info]).to eql(PDF::Reader::Reference.new(56,0))
   end
 end
 
@@ -357,7 +357,7 @@ describe PDF::Reader::ObjectHash, "pdf_version method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    h.pdf_version.should eql(1.4)
+    expect(h.pdf_version).to eql(1.4)
   end
 end
 
@@ -369,8 +369,8 @@ describe PDF::Reader::ObjectHash, "page_references method" do
       h = PDF::Reader::ObjectHash.new(filename)
 
       arr = h.page_references
-      arr.size.should eql(4)
-      arr.map { |ref| ref.id }.should eql([4, 7, 10, 13])
+      expect(arr.size).to eql(4)
+      expect(arr.map { |ref| ref.id }).to eql([4, 7, 10, 13])
     end
   end
 
@@ -380,8 +380,8 @@ describe PDF::Reader::ObjectHash, "page_references method" do
       h = PDF::Reader::ObjectHash.new(filename)
 
       arr = h.page_references
-      arr.size.should eql(1)
-      arr.map { |ref| ref.id }.should eql([6])
+      expect(arr.size).to eql(1)
+      expect(arr.map { |ref| ref.id }).to eql([6])
     end
   end
 end

--- a/spec/object_stream_spec.rb
+++ b/spec/object_stream_spec.rb
@@ -13,18 +13,18 @@ describe PDF::Reader::ObjectStream, "[] method" do
     stream = PDF::Reader::Stream.new(@hash, @data)
     obj_stream = PDF::Reader::ObjectStream.new(stream)
 
-    obj_stream[29].should be_a_kind_of(::Hash)
-    obj_stream[30].should be_a_kind_of(::Hash)
+    expect(obj_stream[29]).to be_a_kind_of(::Hash)
+    expect(obj_stream[30]).to be_a_kind_of(::Hash)
 
-    obj_stream[29][:Type].should eql(:StructTreeRoot)
-    obj_stream[30][:S].should eql(:Document)
+    expect(obj_stream[29][:Type]).to eql(:StructTreeRoot)
+    expect(obj_stream[30][:S]).to eql(:Document)
   end
 
   it "should return nil for objects it doesn't contain" do
     stream = PDF::Reader::Stream.new(@hash, @data)
     obj_stream = PDF::Reader::ObjectStream.new(stream)
 
-    obj_stream[1].should be_nil
+    expect(obj_stream[1]).to be_nil
   end
 
 end
@@ -40,7 +40,7 @@ describe PDF::Reader::ObjectStream, "size method" do
     stream = PDF::Reader::Stream.new(@hash, @data)
     obj_stream = PDF::Reader::ObjectStream.new(stream)
 
-    obj_stream.size.should eql(2)
+    expect(obj_stream.size).to eql(2)
   end
 
 end

--- a/spec/page_layout_spec.rb
+++ b/spec/page_layout_spec.rb
@@ -10,7 +10,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new([], mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == ""
+        expect(subject.to_s).to eq("")
       end
     end
     context "with one word" do
@@ -22,7 +22,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new(runs, mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == "Hello"
+        expect(subject.to_s).to eq("Hello")
       end
     end
     context "with one run directly below another" do
@@ -35,7 +35,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new(runs, mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == "Hello\nWorld"
+        expect(subject.to_s).to eq("Hello\nWorld")
       end
     end
     context "with one two words on one line, separated by a font size gap" do
@@ -48,7 +48,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new(runs, mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == "Hello World"
+        expect(subject.to_s).to eq("Hello World")
       end
     end
 
@@ -62,7 +62,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new(runs, mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == "Hello World"
+        expect(subject.to_s).to eq("Hello World")
       end
     end
 
@@ -76,7 +76,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new(runs, mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == "Hello  World"
+        expect(subject.to_s).to eq("Hello  World")
       end
     end
 
@@ -90,7 +90,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new(runs, mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == "Hello\n World"
+        expect(subject.to_s).to eq("Hello\n World")
       end
     end
 
@@ -104,7 +104,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new(runs, mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == " Hello\nWorld"
+        expect(subject.to_s).to eq(" Hello\nWorld")
       end
     end
 
@@ -118,7 +118,7 @@ describe PDF::Reader::PageLayout, "#to_s" do
       subject { PDF::Reader::PageLayout.new(runs, mediabox)}
 
       it "should return a correct string" do
-        subject.to_s.should == "Hello\n\nWorld"
+        expect(subject.to_s).to eq("Hello\n\nWorld")
       end
     end
   end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -7,7 +7,7 @@ describe PDF::Reader::Page, "raw_content()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.raw_content.should be_a_kind_of(String)
+    expect(@page.raw_content).to be_a_kind_of(String)
   end
 end
 
@@ -18,7 +18,7 @@ describe PDF::Reader::Page, "text()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.text.should eql("Hello James")
+    expect(@page.text).to eql("Hello James")
   end
 
 end
@@ -35,7 +35,7 @@ describe PDF::Reader::Page, "walk()" do
 
       callbacks = receiver.callbacks.map { |cb| cb[:name] }
 
-      callbacks.first.should eql(:page=)
+      expect(callbacks.first).to eql(:page=)
     end
 
     it "should run callbacks while walking content stream" do
@@ -44,9 +44,9 @@ describe PDF::Reader::Page, "walk()" do
 
       callbacks = receiver.callbacks.map { |cb| cb[:name] }
 
-      callbacks.size.should eql(16)
-      callbacks[0].should eql(:page=)
-      callbacks[1].should eql(:save_graphics_state)
+      expect(callbacks.size).to eql(16)
+      expect(callbacks[0]).to eql(:page=)
+      expect(callbacks[1]).to eql(:save_graphics_state)
     end
 
     it "should run callbacks on multiple receivers while walking content stream" do
@@ -56,13 +56,13 @@ describe PDF::Reader::Page, "walk()" do
 
       callbacks = receiver_one.callbacks.map { |cb| cb[:name] }
 
-      callbacks.size.should eql(16)
-      callbacks.first.should eql(:page=)
+      expect(callbacks.size).to eql(16)
+      expect(callbacks.first).to eql(:page=)
 
       callbacks = receiver_two.callbacks.map { |cb| cb[:name] }
 
-      callbacks.size.should eql(16)
-      callbacks.first.should eql(:page=)
+      expect(callbacks.size).to eql(16)
+      expect(callbacks.first).to eql(:page=)
     end
   end
 end
@@ -73,7 +73,7 @@ describe PDF::Reader::Page, "number()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.number.should eql(1)
+    expect(@page.number).to eql(1)
   end
 
 end
@@ -84,7 +84,7 @@ describe PDF::Reader::Page, "number()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.number.should eql(1)
+    expect(@page.number).to eql(1)
   end
 
 end
@@ -96,8 +96,8 @@ describe PDF::Reader::Page, "attributes()" do
     @page    = @browser.page(1)
 
     attribs = @page.attributes
-    attribs[:Resources].should      be_a_kind_of(Hash)
-    attribs[:Resources].size.should eql(2)
+    expect(attribs[:Resources]).to      be_a_kind_of(Hash)
+    expect(attribs[:Resources].size).to eql(2)
   end
 
   it "should contain inherited attributes" do
@@ -105,7 +105,7 @@ describe PDF::Reader::Page, "attributes()" do
     @page    = @browser.page(1)
 
     attribs = @page.attributes
-    attribs[:MediaBox].should eql([0.0, 0.0, 595.276, 841.89])
+    expect(attribs[:MediaBox]).to eql([0.0, 0.0, 595.276, 841.89])
   end
 
   it "should allow Page to override inherited attributes" do
@@ -113,7 +113,7 @@ describe PDF::Reader::Page, "attributes()" do
     @page    = @browser.page(1)
 
     attribs = @page.attributes
-    attribs[:MediaBox].should eql([0, 0, 200, 200])
+    expect(attribs[:MediaBox]).to eql([0, 0, 200, 200])
   end
 
   it "should not include attributes from the Pages object that don't belong on a Page" do
@@ -121,7 +121,7 @@ describe PDF::Reader::Page, "attributes()" do
     @page    = @browser.page(1)
 
     attribs = @page.attributes
-    attribs[:Kids].should be_nil
+    expect(attribs[:Kids]).to be_nil
   end
 
   it "should not include attributes from the Pages object that don't belong on a Page" do
@@ -129,7 +129,7 @@ describe PDF::Reader::Page, "attributes()" do
     @page    = @browser.page(1)
 
     attribs = @page.attributes
-    attribs[:TrimBox].should be_nil
+    expect(attribs[:TrimBox]).to be_nil
   end
 
   it "should always include Type => Page" do
@@ -137,7 +137,7 @@ describe PDF::Reader::Page, "attributes()" do
     @page    = @browser.page(1)
 
     attribs = @page.attributes
-    attribs[:Type].should eql(:Page)
+    expect(attribs[:Type]).to eql(:Page)
   end
 
   it 'should assume 8.5" x 11" if MediaBox is missing (matches Acrobat behaviour)' do
@@ -145,7 +145,7 @@ describe PDF::Reader::Page, "attributes()" do
     @page    = @browser.page(1)
 
     attribs = @page.attributes
-    attribs[:MediaBox].should eql([0,0,612,792])
+    expect(attribs[:MediaBox]).to eql([0,0,612,792])
   end
 end
 
@@ -156,18 +156,18 @@ describe PDF::Reader::Page, "fonts()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.fonts.should      be_a_kind_of(Hash)
-    @page.fonts.size.should eql(1)
-    @page.fonts.keys.should eql([:"CairoFont-0-0"])
+    expect(@page.fonts).to      be_a_kind_of(Hash)
+    expect(@page.fonts.size).to eql(1)
+    expect(@page.fonts.keys).to eql([:"CairoFont-0-0"])
   end
 
   it "should contain inherited resources" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.fonts.should      be_a_kind_of(Hash)
-    @page.fonts.size.should eql(1)
-    @page.fonts.keys.should eql([:"CairoFont-0-0"])
+    expect(@page.fonts).to      be_a_kind_of(Hash)
+    expect(@page.fonts.size).to eql(1)
+    expect(@page.fonts.keys).to eql([:"CairoFont-0-0"])
   end
 
 end
@@ -178,8 +178,8 @@ describe PDF::Reader::Page, "color_spaces()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.color_spaces.should      be_a_kind_of(Hash)
-    @page.color_spaces.size.should eql(0)
+    expect(@page.color_spaces).to      be_a_kind_of(Hash)
+    expect(@page.color_spaces.size).to eql(0)
   end
 end
 
@@ -189,8 +189,8 @@ describe PDF::Reader::Page, "graphic_states()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.graphic_states.should      be_a_kind_of(Hash)
-    @page.graphic_states.size.should eql(1)
+    expect(@page.graphic_states).to      be_a_kind_of(Hash)
+    expect(@page.graphic_states.size).to eql(1)
   end
 end
 
@@ -202,7 +202,7 @@ describe PDF::Reader::Page, "orientation()" do
   it "should return the orientation of portrait.pdf page 1 as 'portrait'" do
     @browser = PDF::Reader.new(pdf_spec_file("portrait"))
     @page    = @browser.page(1)
-    @page.orientation.should eql("portrait")
+    expect(@page.orientation).to eql("portrait")
   end
 
 end
@@ -213,8 +213,8 @@ describe PDF::Reader::Page, "patterns()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.patterns.should      be_a_kind_of(Hash)
-    @page.patterns.size.should eql(0)
+    expect(@page.patterns).to      be_a_kind_of(Hash)
+    expect(@page.patterns.size).to eql(0)
   end
 end
 
@@ -224,8 +224,8 @@ describe PDF::Reader::Page, "procedure_sets()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.procedure_sets.should      be_a_kind_of(Array)
-    @page.procedure_sets.size.should eql(0)
+    expect(@page.procedure_sets).to      be_a_kind_of(Array)
+    expect(@page.procedure_sets.size).to eql(0)
   end
 end
 
@@ -235,8 +235,8 @@ describe PDF::Reader::Page, "properties()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.properties.should      be_a_kind_of(Hash)
-    @page.properties.size.should eql(0)
+    expect(@page.properties).to      be_a_kind_of(Hash)
+    expect(@page.properties.size).to eql(0)
   end
 end
 
@@ -246,8 +246,8 @@ describe PDF::Reader::Page, "shadings()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.shadings.should      be_a_kind_of(Hash)
-    @page.shadings.size.should eql(0)
+    expect(@page.shadings).to      be_a_kind_of(Hash)
+    expect(@page.shadings.size).to eql(0)
   end
 end
 
@@ -257,7 +257,7 @@ describe PDF::Reader::Page, "xobjects()" do
     @browser = PDF::Reader.new(pdf_spec_file("cairo-basic"))
     @page    = @browser.page(1)
 
-    @page.xobjects.should      be_a_kind_of(Hash)
-    @page.xobjects.size.should eql(0)
+    expect(@page.xobjects).to      be_a_kind_of(Hash)
+    expect(@page.xobjects.size).to eql(0)
   end
 end

--- a/spec/page_state_spec.rb
+++ b/spec/page_state_spec.rb
@@ -3,7 +3,7 @@
 require File.dirname(__FILE__) + "/spec_helper"
 
 describe PDF::Reader::PageState do
-  let!(:page)   { mock(:cache => {},
+  let!(:page)   { double(:cache => {},
                         :objects => {},
                         :fonts => {},
                         :xobjects => {},
@@ -13,7 +13,7 @@ describe PDF::Reader::PageState do
     subject { PDF::Reader::PageState::DEFAULT_GRAPHICS_STATE }
 
     context "when walking more than one page" do
-      let!(:expect) { PDF::Reader::PageState::DEFAULT_GRAPHICS_STATE.dup }
+      let!(:expected) { PDF::Reader::PageState::DEFAULT_GRAPHICS_STATE.dup }
 
       before do
         2.times do
@@ -24,7 +24,7 @@ describe PDF::Reader::PageState do
       end
 
       it "should not mutate" do
-        should eql(expect)
+        expect(subject).to eql(expected)
       end
     end
   end
@@ -34,9 +34,9 @@ describe PDF::Reader::PageState do
       let!(:state)  {PDF::Reader::PageState.new(page) }
 
       it "should increase the stack depth by one" do
-        lambda {
+        expect {
           state.save_graphics_state
-        }.should change(state, :stack_depth).from(1).to(2)
+        }.to change(state, :stack_depth).from(1).to(2)
       end
     end
   end
@@ -48,9 +48,9 @@ describe PDF::Reader::PageState do
       it "should reduce the stack depth by one" do
         state.save_graphics_state
 
-        lambda {
+        expect {
           state.restore_graphics_state
-        }.should change(state, :stack_depth).from(2).to(1)
+        }.to change(state, :stack_depth).from(2).to(1)
       end
     end
   end
@@ -67,10 +67,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.ctm_transform(0,0).should == [0, 0]
-        state.ctm_transform(0,1).should == [0, 1]
-        state.ctm_transform(1,0).should == [2, 0]
-        state.ctm_transform(1,1).should == [2, 1]
+        expect(state.ctm_transform(0,0)).to eq([0, 0])
+        expect(state.ctm_transform(0,1)).to eq([0, 1])
+        expect(state.ctm_transform(1,0)).to eq([2, 0])
+        expect(state.ctm_transform(1,1)).to eq([2, 1])
       end
     end
 
@@ -83,10 +83,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.ctm_transform(0,0).should == [0, 0]
-        state.ctm_transform(0,1).should == [0, 1]
-        state.ctm_transform(1,0).should == [1, 2]
-        state.ctm_transform(1,1).should == [1, 3]
+        expect(state.ctm_transform(0,0)).to eq([0, 0])
+        expect(state.ctm_transform(0,1)).to eq([0, 1])
+        expect(state.ctm_transform(1,0)).to eq([1, 2])
+        expect(state.ctm_transform(1,1)).to eq([1, 3])
       end
     end
 
@@ -99,10 +99,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.ctm_transform(0,0).should == [0, 0]
-        state.ctm_transform(0,1).should == [2, 1]
-        state.ctm_transform(1,0).should == [1, 0]
-        state.ctm_transform(1,1).should == [3, 1]
+        expect(state.ctm_transform(0,0)).to eq([0, 0])
+        expect(state.ctm_transform(0,1)).to eq([2, 1])
+        expect(state.ctm_transform(1,0)).to eq([1, 0])
+        expect(state.ctm_transform(1,1)).to eq([3, 1])
       end
     end
 
@@ -115,10 +115,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.ctm_transform(0,0).should == [0, 0]
-        state.ctm_transform(0,1).should == [0, 2]
-        state.ctm_transform(1,0).should == [1, 0]
-        state.ctm_transform(1,1).should == [1, 2]
+        expect(state.ctm_transform(0,0)).to eq([0, 0])
+        expect(state.ctm_transform(0,1)).to eq([0, 2])
+        expect(state.ctm_transform(1,0)).to eq([1, 0])
+        expect(state.ctm_transform(1,1)).to eq([1, 2])
       end
     end
 
@@ -131,10 +131,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.ctm_transform(0,0).should == [2, 0]
-        state.ctm_transform(0,1).should == [2, 1]
-        state.ctm_transform(1,0).should == [3, 0]
-        state.ctm_transform(1,1).should == [3, 1]
+        expect(state.ctm_transform(0,0)).to eq([2, 0])
+        expect(state.ctm_transform(0,1)).to eq([2, 1])
+        expect(state.ctm_transform(1,0)).to eq([3, 0])
+        expect(state.ctm_transform(1,1)).to eq([3, 1])
       end
     end
 
@@ -147,10 +147,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.ctm_transform(0,0).should == [0, 2]
-        state.ctm_transform(0,1).should == [0, 3]
-        state.ctm_transform(1,0).should == [1, 2]
-        state.ctm_transform(1,1).should == [1, 3]
+        expect(state.ctm_transform(0,0)).to eq([0, 2])
+        expect(state.ctm_transform(0,1)).to eq([0, 3])
+        expect(state.ctm_transform(1,0)).to eq([1, 2])
+        expect(state.ctm_transform(1,1)).to eq([1, 3])
       end
     end
 
@@ -167,10 +167,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.ctm_transform(0,0).should == [-10,10]
-        state.ctm_transform(0,1).should == [-11,10]
-        state.ctm_transform(1,0).should == [-10,11]
-        state.ctm_transform(1,1).should == [-11,11]
+        expect(state.ctm_transform(0,0)).to eq([-10,10])
+        expect(state.ctm_transform(0,1)).to eq([-11,10])
+        expect(state.ctm_transform(1,0)).to eq([-10,11])
+        expect(state.ctm_transform(1,1)).to eq([-11,11])
       end
     end
   end
@@ -183,10 +183,10 @@ describe PDF::Reader::PageState do
         state.begin_text_object
         state.set_text_font_and_size(:Test, 12)
 
-        state.trm_transform(0,0).should == [0,0]
-        state.trm_transform(0,1).should == [0, 12]
-        state.trm_transform(1,0).should == [12, 0]
-        state.trm_transform(1,1).should == [12, 12]
+        expect(state.trm_transform(0,0)).to eq([0,0])
+        expect(state.trm_transform(0,1)).to eq([0, 12])
+        expect(state.trm_transform(1,0)).to eq([12, 0])
+        expect(state.trm_transform(1,1)).to eq([12, 12])
       end
     end
   end
@@ -203,10 +203,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.trm_transform(0,0).should == [5,10]
-        state.trm_transform(0,1).should == [5, 22]
-        state.trm_transform(1,0).should == [17, 10]
-        state.trm_transform(1,1).should == [17, 22]
+        expect(state.trm_transform(0,0)).to eq([5,10])
+        expect(state.trm_transform(0,1)).to eq([5, 22])
+        expect(state.trm_transform(1,0)).to eq([17, 10])
+        expect(state.trm_transform(1,1)).to eq([17, 22])
       end
     end
   end
@@ -223,10 +223,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.trm_transform(0,0).should == [5, 10]
-        state.trm_transform(0,1).should == [5, 22]
-        state.trm_transform(1,0).should == [17, 10]
-        state.trm_transform(1,1).should == [17, 22]
+        expect(state.trm_transform(0,0)).to eq([5, 10])
+        expect(state.trm_transform(0,1)).to eq([5, 22])
+        expect(state.trm_transform(1,0)).to eq([17, 10])
+        expect(state.trm_transform(1,1)).to eq([17, 22])
       end
 
       it "should correctly alter the text leading" do
@@ -234,7 +234,7 @@ describe PDF::Reader::PageState do
         state.set_text_font_and_size(:Test, 12)
         state.move_text_position_and_set_leading(5, 10)
 
-        state.clone_state[:text_leading].should == -10
+        expect(state.clone_state[:text_leading]).to eq(-10)
       end
     end
   end
@@ -251,10 +251,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.trm_transform(0,0).should == [5, 6]
-        state.trm_transform(0,1).should == [41, 54]
-        state.trm_transform(1,0).should == [17, 30]
-        state.trm_transform(1,1).should == [53.0, 78.0]
+        expect(state.trm_transform(0,0)).to eq([5, 6])
+        expect(state.trm_transform(0,1)).to eq([41, 54])
+        expect(state.trm_transform(1,0)).to eq([17, 30])
+        expect(state.trm_transform(1,1)).to eq([53.0, 78.0])
       end
     end
   end
@@ -272,10 +272,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.trm_transform(0,0).should == [0, -15]
-        state.trm_transform(0,1).should == [0, -3]
-        state.trm_transform(1,0).should == [12, -15]
-        state.trm_transform(1,1).should == [12, -3]
+        expect(state.trm_transform(0,0)).to eq([0, -15])
+        expect(state.trm_transform(0,1)).to eq([0, -3])
+        expect(state.trm_transform(1,0)).to eq([12, -15])
+        expect(state.trm_transform(1,1)).to eq([12, -3])
       end
     end
   end
@@ -293,10 +293,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.trm_transform(0,0).should == [0, -15]
-        state.trm_transform(0,1).should == [0, -3]
-        state.trm_transform(1,0).should == [12, -15]
-        state.trm_transform(1,1).should == [12, -3]
+        expect(state.trm_transform(0,0)).to eq([0, -15])
+        expect(state.trm_transform(0,1)).to eq([0, -3])
+        expect(state.trm_transform(1,0)).to eq([12, -15])
+        expect(state.trm_transform(1,1)).to eq([12, -3])
       end
     end
   end
@@ -314,10 +314,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.trm_transform(0,0).should == [0, -15]
-        state.trm_transform(0,1).should == [0, -3]
-        state.trm_transform(1,0).should == [12, -15]
-        state.trm_transform(1,1).should == [12, -3]
+        expect(state.trm_transform(0,0)).to eq([0, -15])
+        expect(state.trm_transform(0,1)).to eq([0, -3])
+        expect(state.trm_transform(1,0)).to eq([12, -15])
+        expect(state.trm_transform(1,1)).to eq([12, -3])
       end
     end
   end
@@ -329,13 +329,13 @@ describe PDF::Reader::PageState do
       it "should set word spacing" do
         state.begin_text_object
         state.set_spacing_next_line_show_text(10, 20, "test")
-        state.clone_state[:word_spacing].should == 10
+        expect(state.clone_state[:word_spacing]).to eq(10)
       end
 
       it "should set character spacing" do
         state.begin_text_object
         state.set_spacing_next_line_show_text(10, 20, "test")
-        state.clone_state[:char_spacing].should == 20
+        expect(state.clone_state[:char_spacing]).to eq(20)
       end
 
       it "should correctly alter the text position" do
@@ -346,10 +346,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.trm_transform(0,0).should == [0, 0]
-        state.trm_transform(0,1).should == [0, 12]
-        state.trm_transform(1,0).should == [12, 0]
-        state.trm_transform(1,1).should == [12, 12]
+        expect(state.trm_transform(0,0)).to eq([0, 0])
+        expect(state.trm_transform(0,1)).to eq([0, 12])
+        expect(state.trm_transform(1,0)).to eq([12, 0])
+        expect(state.trm_transform(1,1)).to eq([12, 12])
       end
     end
   end
@@ -366,10 +366,10 @@ describe PDF::Reader::PageState do
         # how the matrix is stored and multiplied is really an implementation
         # detail, so it's better to check the results indirectly via the API
         # external collaborators will use
-        state.trm_transform(0,0).should == [40, 700]
-        state.trm_transform(0,1).should == [40, 712]
-        state.trm_transform(1,0).should == [52, 700]
-        state.trm_transform(1,1).should == [52, 712]
+        expect(state.trm_transform(0,0)).to eq([40, 700])
+        expect(state.trm_transform(0,1)).to eq([40, 712])
+        expect(state.trm_transform(1,0)).to eq([52, 700])
+        expect(state.trm_transform(1,1)).to eq([52, 712])
       end
 
       context "2pt glyph width" do
@@ -381,10 +381,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 0, false)
 
-                  state.trm_transform(0,0).should == [64, 700]
-                  state.trm_transform(0,1).should == [64, 712]
-                  state.trm_transform(1,0).should == [76, 700]
-                  state.trm_transform(1,1).should == [76, 712]
+                  expect(state.trm_transform(0,0)).to eq([64, 700])
+                  expect(state.trm_transform(0,1)).to eq([64, 712])
+                  expect(state.trm_transform(1,0)).to eq([76, 700])
+                  expect(state.trm_transform(1,1)).to eq([76, 712])
                 end
               end
               context "a word boundary" do
@@ -392,10 +392,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 0, true)
 
-                  state.trm_transform(0,0).should == [64, 700]
-                  state.trm_transform(0,1).should == [64, 712]
-                  state.trm_transform(1,0).should == [76, 700]
-                  state.trm_transform(1,1).should == [76, 712]
+                  expect(state.trm_transform(0,0)).to eq([64, 700])
+                  expect(state.trm_transform(0,1)).to eq([64, 712])
+                  expect(state.trm_transform(1,0)).to eq([76, 700])
+                  expect(state.trm_transform(1,1)).to eq([76, 712])
                 end
               end
             end
@@ -405,10 +405,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 2, false)
 
-                  state.trm_transform(0,0).should == [63.976, 700]
-                  state.trm_transform(0,1).should == [63.976, 712]
-                  state.trm_transform(1,0).should == [75.976, 700]
-                  state.trm_transform(1,1).should == [75.976, 712]
+                  expect(state.trm_transform(0,0)).to eq([63.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([63.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([75.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([75.976, 712])
                 end
               end
               context "a word boundary" do
@@ -416,10 +416,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 2, true)
 
-                  state.trm_transform(0,0).should == [63.976, 700]
-                  state.trm_transform(0,1).should == [63.976, 712]
-                  state.trm_transform(1,0).should == [75.976, 700]
-                  state.trm_transform(1,1).should == [75.976, 712]
+                  expect(state.trm_transform(0,0)).to eq([63.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([63.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([75.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([75.976, 712])
                 end
               end
             end
@@ -434,10 +434,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 0, false)
 
-                  state.trm_transform(0,0).should == [64, 700]
-                  state.trm_transform(0,1).should == [64, 712]
-                  state.trm_transform(1,0).should == [76, 700]
-                  state.trm_transform(1,1).should == [76, 712]
+                  expect(state.trm_transform(0,0)).to eq([64, 700])
+                  expect(state.trm_transform(0,1)).to eq([64, 712])
+                  expect(state.trm_transform(1,0)).to eq([76, 700])
+                  expect(state.trm_transform(1,1)).to eq([76, 712])
                 end
               end
               context "a word boundary" do
@@ -445,10 +445,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 0, true)
 
-                  state.trm_transform(0,0).should == [65, 700]
-                  state.trm_transform(0,1).should == [65, 712]
-                  state.trm_transform(1,0).should == [77, 700]
-                  state.trm_transform(1,1).should == [77, 712]
+                  expect(state.trm_transform(0,0)).to eq([65, 700])
+                  expect(state.trm_transform(0,1)).to eq([65, 712])
+                  expect(state.trm_transform(1,0)).to eq([77, 700])
+                  expect(state.trm_transform(1,1)).to eq([77, 712])
                 end
               end
             end
@@ -458,10 +458,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 2, false)
 
-                  state.trm_transform(0,0).should == [63.976, 700]
-                  state.trm_transform(0,1).should == [63.976, 712]
-                  state.trm_transform(1,0).should == [75.976, 700]
-                  state.trm_transform(1,1).should == [75.976, 712]
+                  expect(state.trm_transform(0,0)).to eq([63.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([63.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([75.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([75.976, 712])
                 end
               end
               context "a word boundary" do
@@ -469,10 +469,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 2, true)
 
-                  state.trm_transform(0,0).should == [64.976, 700]
-                  state.trm_transform(0,1).should == [64.976, 712]
-                  state.trm_transform(1,0).should == [76.976, 700]
-                  state.trm_transform(1,1).should == [76.976, 712]
+                  expect(state.trm_transform(0,0)).to eq([64.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([64.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([76.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([76.976, 712])
                 end
               end
             end
@@ -489,10 +489,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 0, false)
 
-                  state.trm_transform(0,0).should == [65, 700]
-                  state.trm_transform(0,1).should == [65, 712]
-                  state.trm_transform(1,0).should == [77, 700]
-                  state.trm_transform(1,1).should == [77, 712]
+                  expect(state.trm_transform(0,0)).to eq([65, 700])
+                  expect(state.trm_transform(0,1)).to eq([65, 712])
+                  expect(state.trm_transform(1,0)).to eq([77, 700])
+                  expect(state.trm_transform(1,1)).to eq([77, 712])
                 end
               end
               context "a word boundary" do
@@ -500,10 +500,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 0, true)
 
-                  state.trm_transform(0,0).should == [65, 700]
-                  state.trm_transform(0,1).should == [65, 712]
-                  state.trm_transform(1,0).should == [77, 700]
-                  state.trm_transform(1,1).should == [77, 712]
+                  expect(state.trm_transform(0,0)).to eq([65, 700])
+                  expect(state.trm_transform(0,1)).to eq([65, 712])
+                  expect(state.trm_transform(1,0)).to eq([77, 700])
+                  expect(state.trm_transform(1,1)).to eq([77, 712])
                 end
               end
             end
@@ -513,10 +513,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 2, false)
 
-                  state.trm_transform(0,0).should == [64.976, 700]
-                  state.trm_transform(0,1).should == [64.976, 712]
-                  state.trm_transform(1,0).should == [76.976, 700]
-                  state.trm_transform(1,1).should == [76.976, 712]
+                  expect(state.trm_transform(0,0)).to eq([64.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([64.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([76.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([76.976, 712])
                 end
               end
               context "a word boundary" do
@@ -524,10 +524,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 2, true)
 
-                  state.trm_transform(0,0).should == [64.976, 700]
-                  state.trm_transform(0,1).should == [64.976, 712]
-                  state.trm_transform(1,0).should == [76.976, 700]
-                  state.trm_transform(1,1).should == [76.976, 712]
+                  expect(state.trm_transform(0,0)).to eq([64.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([64.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([76.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([76.976, 712])
                 end
               end
             end
@@ -542,10 +542,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 0, false)
 
-                  state.trm_transform(0,0).should == [65, 700]
-                  state.trm_transform(0,1).should == [65, 712]
-                  state.trm_transform(1,0).should == [77, 700]
-                  state.trm_transform(1,1).should == [77, 712]
+                  expect(state.trm_transform(0,0)).to eq([65, 700])
+                  expect(state.trm_transform(0,1)).to eq([65, 712])
+                  expect(state.trm_transform(1,0)).to eq([77, 700])
+                  expect(state.trm_transform(1,1)).to eq([77, 712])
                 end
               end
               context "a word boundary" do
@@ -553,10 +553,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 0, true)
 
-                  state.trm_transform(0,0).should == [66, 700]
-                  state.trm_transform(0,1).should == [66, 712]
-                  state.trm_transform(1,0).should == [78, 700]
-                  state.trm_transform(1,1).should == [78, 712]
+                  expect(state.trm_transform(0,0)).to eq([66, 700])
+                  expect(state.trm_transform(0,1)).to eq([66, 712])
+                  expect(state.trm_transform(1,0)).to eq([78, 700])
+                  expect(state.trm_transform(1,1)).to eq([78, 712])
                 end
               end
             end
@@ -566,10 +566,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 2, false)
 
-                  state.trm_transform(0,0).should == [64.976, 700]
-                  state.trm_transform(0,1).should == [64.976, 712]
-                  state.trm_transform(1,0).should == [76.976, 700]
-                  state.trm_transform(1,1).should == [76.976, 712]
+                  expect(state.trm_transform(0,0)).to eq([64.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([64.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([76.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([76.976, 712])
                 end
               end
               context "a word boundary" do
@@ -577,10 +577,10 @@ describe PDF::Reader::PageState do
                 it "should correctly alter the text matrix" do
                   state.process_glyph_displacement(2, 2, true)
 
-                  state.trm_transform(0,0).should == [65.976, 700]
-                  state.trm_transform(0,1).should == [65.976, 712]
-                  state.trm_transform(1,0).should == [77.976, 700]
-                  state.trm_transform(1,1).should == [77.976, 712]
+                  expect(state.trm_transform(0,0)).to eq([65.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([65.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([77.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([77.976, 712])
                 end
               end
             end

--- a/spec/page_text_receiver_spec.rb
+++ b/spec/page_text_receiver_spec.rb
@@ -11,7 +11,7 @@ describe PDF::Reader::PageTextReceiver do
 
     @page.walk(@receiver)
 
-    @receiver.content.should eql("Hello James")
+    expect(@receiver.content).to eql("Hello James")
   end
 
   it "should return the text content from cairo-multiline.pdf page 1" do
@@ -21,7 +21,7 @@ describe PDF::Reader::PageTextReceiver do
 
     @page.walk(@receiver)
 
-    @receiver.content.should match(/\AHello World$.+^From James\Z/m)
+    expect(@receiver.content).to match(/\AHello World$.+^From James\Z/m)
   end
 
   it "should return the text content from Form XObjects" do
@@ -31,7 +31,7 @@ describe PDF::Reader::PageTextReceiver do
 
     @page.walk(@receiver)
 
-    @receiver.content.should eql("James Healy")
+    expect(@receiver.content).to eql("James Healy")
   end
 
   it "should return merged text content from the regular page and a Form XObjects" do
@@ -41,7 +41,7 @@ describe PDF::Reader::PageTextReceiver do
 
     @page.walk(@receiver)
 
-    @receiver.content.should match(/\AJames Healy$.+^Some regular content\Z/m)
+    expect(@receiver.content).to match(/\AJames Healy$.+^Some regular content\Z/m)
   end
 
   it "should correctly parse a page with nested Form XObjects" do
@@ -51,7 +51,7 @@ describe PDF::Reader::PageTextReceiver do
 
     @page.walk(@receiver)
 
-    @receiver.content.should eql("")
+    expect(@receiver.content).to eql("")
   end
 
   it "should correctly parse a page with nested Form XObjects" do
@@ -61,7 +61,7 @@ describe PDF::Reader::PageTextReceiver do
 
     @page.walk(@receiver)
 
-    @receiver.content.should match(/\Aone$.+^two$.+^three$.+^four\Z/m)
+    expect(@receiver.content).to match(/\Aone$.+^two$.+^three$.+^four\Z/m)
   end
 
 end

--- a/spec/pages_strategy_spec.rb
+++ b/spec/pages_strategy_spec.rb
@@ -16,13 +16,13 @@ describe PDF::Reader::PagesStrategy do
 
       # mock up an object that will be called with callbacks. This will test that
       # the content class correctly recognises all instructions
-      receiver = mock("receiver")
-      receiver.should_receive(:begin_text_object).once             # BT
-      receiver.should_receive(:move_text_position).once            # Td
-      receiver.should_receive(:set_text_font_and_size).once        # Tf
-      receiver.should_receive(:set_text_rendering_mode).once       # Tr
-      receiver.should_receive(:show_text).once                     # Tj
-      receiver.should_receive(:end_text_object).once               # ET
+      receiver = double("receiver")
+      expect(receiver).to receive(:begin_text_object).once             # BT
+      expect(receiver).to receive(:move_text_position).once            # Td
+      expect(receiver).to receive(:set_text_font_and_size).once        # Tf
+      expect(receiver).to receive(:set_text_rendering_mode).once       # Tr
+      expect(receiver).to receive(:show_text).once                     # Tj
+      expect(receiver).to receive(:end_text_object).once               # ET
 
       # The instructions to test with
       instructions = "BT\n 36.000 794.330 Td\n /F1 10.0 Tf\n 0 Tr\n (047174719X) Tj\n ET"
@@ -37,13 +37,13 @@ describe PDF::Reader::PagesStrategy do
 
     # mock up an object that will be called with callbacks. This will test that
     # the content class correctly recognises all instructions
-    receiver = mock("receiver")
-    receiver.should_receive(:begin_text_object).twice            # BT
-    receiver.should_receive(:move_text_position).twice           # Td
-    receiver.should_receive(:set_text_font_and_size).twice       # Tf
-    receiver.should_receive(:set_text_rendering_mode).twice      # Tr
-    receiver.should_receive(:show_text).twice                    # Tj
-    receiver.should_receive(:end_text_object).twice              # ET
+    receiver = double("receiver")
+    expect(receiver).to receive(:begin_text_object).twice            # BT
+    expect(receiver).to receive(:move_text_position).twice           # Td
+    expect(receiver).to receive(:set_text_font_and_size).twice       # Tf
+    expect(receiver).to receive(:set_text_rendering_mode).twice      # Tr
+    expect(receiver).to receive(:show_text).twice                    # Tj
+    expect(receiver).to receive(:end_text_object).twice              # ET
 
     # The instructions to test with
     instructions = "BT 36.000 794.330 Td /F1 10.0 Tf 0 Tr (047174719X) Tj ET\n BT 36.000 782.770 Td /F1 10.0 Tf 0 Tr (9780300110562) Tj ET"
@@ -57,10 +57,10 @@ describe PDF::Reader::PagesStrategy do
 
     # mock up an object that will be called with callbacks. This will test that
     # the content class correctly recognises all instructions
-    receiver = mock("receiver")
-    receiver.should_receive(:begin_inline_image).once   # BI
-    receiver.should_receive(:begin_inline_image_data).once    # ID
-    receiver.should_receive(:end_inline_image).once     # EI
+    receiver = double("receiver")
+    expect(receiver).to receive(:begin_inline_image).once   # BI
+    expect(receiver).to receive(:begin_inline_image_data).once    # ID
+    expect(receiver).to receive(:end_inline_image).once     # EI
 
     # access a content stream with an inline image
     filename = pdf_spec_file("inline_image")
@@ -87,20 +87,20 @@ describe PDF::Reader::PagesStrategy do
     PDF::Reader.file(filename, receiver)
 
     text_callbacks = receiver.all(:show_text_with_positioning)
-    text_callbacks.size.should eql(2)
-    text_callbacks[0][:args].should eql([["My name is"]])
-    text_callbacks[1][:args].should eql([["James Healy"]])
+    expect(text_callbacks.size).to eql(2)
+    expect(text_callbacks[0][:args]).to eql([["My name is"]])
+    expect(text_callbacks[1][:args]).to eql([["James Healy"]])
   end
 
   it "should send the correct callbacks when using more than one receiver" do
 
     # mock up an object that will be called with callbacks. This will test that
     # the content class correctly recognises all instructions
-    one = mock("receiver_one")
-    one.should_receive(:move_text_position).once # Td
+    one = double("receiver_one")
+    expect(one).to receive(:move_text_position).once # Td
 
-    two = mock("receiver_two")
-    two.should_receive(:move_text_position).once # Td
+    two = double("receiver_two")
+    expect(two).to receive(:move_text_position).once # Td
 
     # The instructions to test with
     instructions = "36.000 794.330 Td"

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -7,16 +7,16 @@ describe PDF::Reader::Parser do
   include EncodingHelper
 
   it "should parse a name correctly" do
-    parse_string("/James").parse_token.should eql(:James)
-    parse_string("/A;Name_With-Various***Characters?").parse_token.should eql(:"A;Name_With-Various***Characters?")
-    parse_string("/1.2").parse_token.should eql(:"1.2")
-    parse_string("/$$").parse_token.should eql(:"$$")
-    parse_string("/@pattern").parse_token.should eql(:"@pattern")
-    parse_string("/.notdef").parse_token.should eql(:".notdef")
-    parse_string("/James#20Healy").parse_token.should eql(:"James Healy")
-    parse_string("/James#23Healy").parse_token.should eql(:"James#Healy")
-    parse_string("/Ja#6des").parse_token.should eql(:"James")
-    parse_string("/Ja#6des").parse_token.should eql(:"James")
+    expect(parse_string("/James").parse_token).to eql(:James)
+    expect(parse_string("/A;Name_With-Various***Characters?").parse_token).to eql(:"A;Name_With-Various***Characters?")
+    expect(parse_string("/1.2").parse_token).to eql(:"1.2")
+    expect(parse_string("/$$").parse_token).to eql(:"$$")
+    expect(parse_string("/@pattern").parse_token).to eql(:"@pattern")
+    expect(parse_string("/.notdef").parse_token).to eql(:".notdef")
+    expect(parse_string("/James#20Healy").parse_token).to eql(:"James Healy")
+    expect(parse_string("/James#23Healy").parse_token).to eql(:"James#Healy")
+    expect(parse_string("/Ja#6des").parse_token).to eql(:"James")
+    expect(parse_string("/Ja#6des").parse_token).to eql(:"James")
   end
 
   # '/' is a valid PDF name, but :"" is only a valid ruby symbol in 1.9
@@ -25,65 +25,65 @@ describe PDF::Reader::Parser do
   # Names as a syntax error
   if RUBY_VERSION >= "1.9"
     it "should parse an empty name correctly" do
-      parse_string("/").parse_token.should eql("".to_sym)
+      expect(parse_string("/").parse_token).to eql("".to_sym)
       parser = parse_string("/\n/")
-      parser.parse_token.should eql("".to_sym)
-      parser.parse_token.should eql("".to_sym)
+      expect(parser.parse_token).to eql("".to_sym)
+      expect(parser.parse_token).to eql("".to_sym)
     end
 
     it "should parse two empty names correctly" do
       parser = parse_string("/ /")
-      parser.parse_token.should eql("".to_sym)
-      parser.parse_token.should eql("".to_sym)
+      expect(parser.parse_token).to eql("".to_sym)
+      expect(parser.parse_token).to eql("".to_sym)
     end
   else
     it "should parse an empty name correctly" do
-      parse_string("/").parse_token.should eql(:" ")
+      expect(parse_string("/").parse_token).to eql(:" ")
       parser = parse_string("/\n/")
-      parser.parse_token.should eql(:" ")
-      parser.parse_token.should eql(:" ")
+      expect(parser.parse_token).to eql(:" ")
+      expect(parser.parse_token).to eql(:" ")
     end
 
     it "should parse two empty names correctly" do
       parser = parse_string("/ /")
-      parser.parse_token.should eql(:" ")
-      parser.parse_token.should eql(:" ")
+      expect(parser.parse_token).to eql(:" ")
+      expect(parser.parse_token).to eql(:" ")
     end
   end
 
   it "should parse booleans correctly" do
-    parse_string("true").parse_token.should be_true
-    parse_string("false").parse_token.should be_false
+    expect(parse_string("true").parse_token).to be_truthy
+    expect(parse_string("false").parse_token).to be_falsey
   end
 
   it "should parse null and nil correctly" do
-    parse_string("").parse_token.should be_nil
-    parse_string("null").parse_token.should be_nil
+    expect(parse_string("").parse_token).to be_nil
+    expect(parse_string("null").parse_token).to be_nil
   end
 
   it "should parse a string correctly" do
-    parse_string("()").parse_token.should eql("")
-    parse_string("(this is a string)").parse_token.should eql("this is a string")
-    parse_string("(this \\n is a string)").parse_token.should eql("this \n is a string")
-    parse_string("(x \\t x)").parse_token.should eql("x \t x")
-    parse_string("(x \\101 x)").parse_token.should eql("x A x")
-    parse_string("(x \\61 x)").parse_token.should eql("x 1 x")
-    parse_string("(x \\1 x)").parse_token.should eql("x \x01 x")
-    parse_string("(x \\( x)").parse_token.should eql("x ( x")
-    parse_string("((x)))").parse_token.should eql("(x)")
-    parse_string("(Adobe)").parse_token.should eql("Adobe")
-    parse_string("(!\"%1)").parse_token.should eql("!\"%1")
-    parse_string("(James\\ Healy)").parse_token.should eql("James Healy")
-    parse_string("(x\nx)").parse_token.should eql("x\nx")
-    parse_string("(x\rx)").parse_token.should eql("x\nx")
-    parse_string("(x\r\nx)").parse_token.should eql("x\nx")
-    parse_string("(x\\rx)").parse_token.should eql("x\rx")
-    parse_string("(\\rx)").parse_token.should eql("\rx")
-    parse_string("(\\r)").parse_token.should eql("\r")
-    parse_string("(x\n\rx)").parse_token.should eql("x\nx")
-    parse_string("(x \\\nx)").parse_token.should eql("x x")
-    parse_string("(\\\\f)").parse_token.should eql("\\f")
-    parse_string("([test])").parse_token.should eql("[test]")
+    expect(parse_string("()").parse_token).to eql("")
+    expect(parse_string("(this is a string)").parse_token).to eql("this is a string")
+    expect(parse_string("(this \\n is a string)").parse_token).to eql("this \n is a string")
+    expect(parse_string("(x \\t x)").parse_token).to eql("x \t x")
+    expect(parse_string("(x \\101 x)").parse_token).to eql("x A x")
+    expect(parse_string("(x \\61 x)").parse_token).to eql("x 1 x")
+    expect(parse_string("(x \\1 x)").parse_token).to eql("x \x01 x")
+    expect(parse_string("(x \\( x)").parse_token).to eql("x ( x")
+    expect(parse_string("((x)))").parse_token).to eql("(x)")
+    expect(parse_string("(Adobe)").parse_token).to eql("Adobe")
+    expect(parse_string("(!\"%1)").parse_token).to eql("!\"%1")
+    expect(parse_string("(James\\ Healy)").parse_token).to eql("James Healy")
+    expect(parse_string("(x\nx)").parse_token).to eql("x\nx")
+    expect(parse_string("(x\rx)").parse_token).to eql("x\nx")
+    expect(parse_string("(x\r\nx)").parse_token).to eql("x\nx")
+    expect(parse_string("(x\\rx)").parse_token).to eql("x\rx")
+    expect(parse_string("(\\rx)").parse_token).to eql("\rx")
+    expect(parse_string("(\\r)").parse_token).to eql("\r")
+    expect(parse_string("(x\n\rx)").parse_token).to eql("x\nx")
+    expect(parse_string("(x \\\nx)").parse_token).to eql("x x")
+    expect(parse_string("(\\\\f)").parse_token).to eql("\\f")
+    expect(parse_string("([test])").parse_token).to eql("[test]")
   end
 
   it "should parse a Unicode string correctly" do
@@ -115,62 +115,62 @@ describe PDF::Reader::Parser do
     seq.each_value do |(src, exp)|
       src = binary_string("(#{bom}#{src})")
       exp = binary_string("#{bom}#{exp}")
-      parse_string(src).parse_token.should eql(exp)
+      expect(parse_string(src).parse_token).to eql(exp)
     end
 
     mixed = [ seq[:straddle_seq_5c6e], seq[:char_5c08], seq[:char_5c0a], seq[:char_5c02], seq[:char_contain_0a] ]
     mixed_src = binary_string("(" + bom + mixed.map {|x| x[0]}.join + ")")
     mixed_exp = binary_string(bom + mixed.map {|x| x[1]}.join)
-    parse_string(mixed_src).parse_token.should eql(mixed_exp)
+    expect(parse_string(mixed_src).parse_token).to eql(mixed_exp)
   end
 
   it "should not leave the closing literal string delimiter in the buffer after parsing a string" do
     parser = parse_string("(this is a string) /James")
-    parser.parse_token.should eql("this is a string")
-    parser.parse_token.should eql(:James)
+    expect(parser.parse_token).to eql("this is a string")
+    expect(parser.parse_token).to eql(:James)
   end
 
   it "should parse a hex string correctly" do
-    parse_string("<48656C6C6F>").parse_token.should eql("Hello")
+    expect(parse_string("<48656C6C6F>").parse_token).to eql("Hello")
   end
 
   it "should ignore whitespace when parsing a hex string" do
-    parse_string("<48656C6C6F20\n4A616D6573>").parse_token.should eql("Hello James")
+    expect(parse_string("<48656C6C6F20\n4A616D6573>").parse_token).to eql("Hello James")
   end
 
   it "should parse dictionary with embedded hex string correctly" do
     dict = parse_string("<< /X <48656C6C6F> >>").parse_token
-    dict.size.should eql(1)
-    dict[:X].should eql("Hello")
+    expect(dict.size).to eql(1)
+    expect(dict[:X]).to eql("Hello")
   end
 
   it "should parse various dictionaries correctly" do
     str = "<< /Registry (Adobe) /Ordering (Japan1) /Supplement 5 >>"
     dict = parse_string(str).parse_token
 
-    dict.size.should eql(3)
-    dict[:Registry].should    eql("Adobe")
-    dict[:Ordering].should    eql("Japan1")
-    dict[:Supplement].should  eql(5)
+    expect(dict.size).to eql(3)
+    expect(dict[:Registry]).to    eql("Adobe")
+    expect(dict[:Ordering]).to    eql("Japan1")
+    expect(dict[:Supplement]).to  eql(5)
   end
 
   it "should parse dictionary with extra space ok" do
     str = "<<\r\n/Type /Pages\r\n/Count 3\r\n/Kids [ 25 0 R 27 0 R]\r\n                                                      \r\n>>"
     dict = parse_string(str).parse_token
-    dict.size.should == 3
+    expect(dict.size).to eq(3)
   end
 
   it "should parse an array correctly" do
-    parse_string("[ 10 0 R 12 0 R ]").parse_token.size.should eql(2)
+    expect(parse_string("[ 10 0 R 12 0 R ]").parse_token.size).to eql(2)
   end
 
   it "should parse numbers correctly" do
     parser = parse_string("1 2 -3 4.5 -5")
-    parser.parse_token.should eql( 1)
-    parser.parse_token.should eql( 2)
-    parser.parse_token.should eql(-3)
-    parser.parse_token.should eql( 4.5)
-    parser.parse_token.should eql(-5)
+    expect(parser.parse_token).to eql( 1)
+    expect(parser.parse_token).to eql( 2)
+    expect(parser.parse_token).to eql(-3)
+    expect(parser.parse_token).to eql( 4.5)
+    expect(parser.parse_token).to eql(-5)
   end
 
 end

--- a/spec/reader/filter/ascii85_spec.rb
+++ b/spec/reader/filter/ascii85_spec.rb
@@ -6,12 +6,12 @@ describe PDF::Reader::Filter::Ascii85 do
   it "should filter a ASCII85 stream correctly" do
     filter = PDF::Reader::Filter::Ascii85.new
     encoded_data = Ascii85::encode("Ruby")
-    filter.filter(encoded_data).should eql("Ruby")
+    expect(filter.filter(encoded_data)).to eql("Ruby")
   end
 
   it "should filter a ASCII85 stream missing <~ correctly" do
     filter = PDF::Reader::Filter::Ascii85.new
     encoded_data = Ascii85::encode("Ruby")[2,100]
-    filter.filter(encoded_data).should eql("Ruby")
+    expect(filter.filter(encoded_data)).to eql("Ruby")
   end
 end

--- a/spec/reader/filter/ascii_hex_spec.rb
+++ b/spec/reader/filter/ascii_hex_spec.rb
@@ -6,18 +6,18 @@ describe PDF::Reader::Filter::AsciiHex do
   it "should filter a ASCIIHex stream correctly" do
     filter = PDF::Reader::Filter::AsciiHex.new
     encoded_data = "<52756279>"
-    filter.filter(encoded_data).should eql("Ruby")
+    expect(filter.filter(encoded_data)).to eql("Ruby")
   end
 
   it "should filter a ASCIIHex stream missing delimiters" do
     filter = PDF::Reader::Filter::AsciiHex.new
     encoded_data = "52756279"
-    filter.filter(encoded_data).should eql("Ruby")
+    expect(filter.filter(encoded_data)).to eql("Ruby")
   end
 
   it "should filter a ASCIIHex stream with an odd number of nibbles" do
     filter = PDF::Reader::Filter::AsciiHex.new
     encoded_data = "5275627"
-    filter.filter(encoded_data).should eql("Rubp")
+    expect(filter.filter(encoded_data)).to eql("Rubp")
   end
 end

--- a/spec/reader/filter/flate_spec.rb
+++ b/spec/reader/filter/flate_spec.rb
@@ -9,7 +9,7 @@ describe PDF::Reader::Filter::Flate do
     filter = PDF::Reader::Filter::Flate.new(:Columns => 5, :Predictor => 12)
     deflated_data    = binread(File.dirname(__FILE__) + "/../../data/deflated_with_predictors.dat")
     depredicted_data = binread(File.dirname(__FILE__) + "/../../data/deflated_with_predictors_result.dat")
-    filter.filter(deflated_data).should eql(depredicted_data)
+    expect(filter.filter(deflated_data)).to eql(depredicted_data)
   end
 
   it "should inflate a deflated stream with tiff predictors correctly" do
@@ -18,7 +18,7 @@ describe PDF::Reader::Filter::Flate do
     predicted_data = "abc\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00abc\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     deflated_data  = Zlib::Deflate.deflate(predicted_data)
 
-    filter.filter(deflated_data).should eql(original_data)
+    expect(filter.filter(deflated_data)).to eql(original_data)
   end
 
 end

--- a/spec/reader/filter/lzw_spec.rb
+++ b/spec/reader/filter/lzw_spec.rb
@@ -7,7 +7,7 @@ describe PDF::Reader::Filter::Lzw do
     filter = PDF::Reader::Filter::Lzw.new
     compressed_data   = binread(File.dirname(__FILE__) + "/../../data/lzw_compressed.dat")
     decompressed_data = binread(File.dirname(__FILE__) + "/../../data/lzw_decompressed.dat")
-    filter.filter(compressed_data).should eql(decompressed_data)
+    expect(filter.filter(compressed_data)).to eql(decompressed_data)
   end
 
 end

--- a/spec/reader/filter/null_spec.rb
+++ b/spec/reader/filter/null_spec.rb
@@ -5,6 +5,6 @@ require File.dirname(__FILE__) + "/../../spec_helper"
 describe PDF::Reader::Filter::Null do
   it "returns the data unchanged" do
     filter = PDF::Reader::Filter::Null.new
-    filter.filter("\x00").should eql("\x00")
+    expect(filter.filter("\x00")).to eql("\x00")
   end
 end

--- a/spec/reader/filter/run_length_spec.rb
+++ b/spec/reader/filter/run_length_spec.rb
@@ -6,6 +6,6 @@ describe PDF::Reader::Filter::RunLength do
   it "should filter a RunLengthDecode stream correctly" do
     filter = PDF::Reader::Filter::RunLength.new
     encoded_data = [2, "\x00"*3, 255, "\x01", 128].pack('Ca*Ca*C')
-    filter.filter(encoded_data).should eql("\x00\x00\x00\x01\x01")
+    expect(filter.filter(encoded_data)).to eql("\x00\x00\x00\x01\x01")
   end
 end

--- a/spec/reader/orientation_detector_spec.rb
+++ b/spec/reader/orientation_detector_spec.rb
@@ -9,7 +9,7 @@ describe PDF::Reader::OrientationDetector, "#orientation" do
       PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 612, 792])
     }
     it "should return portrait" do
-      detector.orientation.should == 'portrait'
+      expect(detector.orientation).to eq('portrait')
     end
   end
 
@@ -18,7 +18,7 @@ describe PDF::Reader::OrientationDetector, "#orientation" do
       PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 612, 792], :Rotate => 270)
     }
     it "should return landscape" do
-      detector.orientation.should == 'landscape'
+      expect(detector.orientation).to eq('landscape')
     end
   end
 
@@ -27,7 +27,7 @@ describe PDF::Reader::OrientationDetector, "#orientation" do
       PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 792, 612])
     }
     it "should return landscape" do
-      detector.orientation.should == 'landscape'
+      expect(detector.orientation).to eq('landscape')
     end
   end
 
@@ -36,7 +36,7 @@ describe PDF::Reader::OrientationDetector, "#orientation" do
       PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 792, 612], :Rotate => 90)
     }
     it "should return portrait" do
-      detector.orientation.should == 'portrait'
+      expect(detector.orientation).to eq('portrait')
     end
   end
 

--- a/spec/reader/register_receiver_spec.rb
+++ b/spec/reader/register_receiver_spec.rb
@@ -7,7 +7,7 @@ describe PDF::Reader::RegisterReceiver do
 
   context "instance" do
     it "responds to any method" do
-      subject.should respond_to(:foo)
+      expect(subject).to respond_to(:foo)
     end
 
     context "with callbacks recorded" do
@@ -20,44 +20,44 @@ describe PDF::Reader::RegisterReceiver do
       let(:foo_baz) { { :name => :foo, :args => [:baz] } }
 
       it "counts correctly" do
-        subject.count(:foo).should == 2
-        subject.count(:other).should == 0
+        expect(subject.count(:foo)).to eq(2)
+        expect(subject.count(:other)).to eq(0)
       end
 
       it "returns callbacks recorded" do
-        subject.all(:foo).should eq [ foo_bar, foo_baz ]
-        subject.all(:other).should be_empty
+        expect(subject.all(:foo)).to eq [ foo_bar, foo_baz ]
+        expect(subject.all(:other)).to be_empty
       end
 
       it "returns callback args" do
-        subject.all_args(:foo).should eq [[:bar], [:baz]]
-        subject.all_args(:other).should be_empty
+        expect(subject.all_args(:foo)).to eq [[:bar], [:baz]]
+        expect(subject.all_args(:other)).to be_empty
       end
 
       it "finds first occurance" do
-        subject.first_occurance_of(:foo).should eq foo_bar
-        subject.first_occurance_of(:other).should be_nil
+        expect(subject.first_occurance_of(:foo)).to eq foo_bar
+        expect(subject.first_occurance_of(:other)).to be_nil
       end
 
       it "finds final occurance" do
-        subject.final_occurance_of(:foo).should eq foo_baz
-        subject.final_occurance_of(:other).should be_nil
+        expect(subject.final_occurance_of(:foo)).to eq foo_baz
+        expect(subject.final_occurance_of(:other)).to be_nil
       end
 
       describe "series()" do
         it "none for no methods" do
-          subject.series.should be_nil
+          expect(subject.series).to be_nil
         end
 
         it "none for unmatched methods" do
-          subject.series(:other).should be_nil
-          subject.series(:foo, :other).should be_nil
-          subject.series(:foo, :foo, :foo).should be_nil
+          expect(subject.series(:other)).to be_nil
+          expect(subject.series(:foo, :other)).to be_nil
+          expect(subject.series(:foo, :foo, :foo)).to be_nil
         end
 
         it "matches series" do
-          subject.series(:foo).should eq [ foo_bar ]
-          subject.series(:foo, :foo).should eq [ foo_bar, foo_baz ]
+          expect(subject.series(:foo)).to eq [ foo_bar ]
+          expect(subject.series(:foo, :foo)).to eq [ foo_bar, foo_baz ]
         end
       end
     end

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -11,37 +11,37 @@ describe PDF::Reader do
 
     it "should pass a reader instance to a block" do
       PDF::Reader.open(cairo_basic) do |reader|
-        reader.pdf_version.should eql(1.4)
+        expect(reader.pdf_version).to eql(1.4)
       end
     end
   end
 
   describe "pdf_version()" do
     it "should return the correct pdf_version" do
-      PDF::Reader.new(cairo_basic).pdf_version.should eql(1.4)
+      expect(PDF::Reader.new(cairo_basic).pdf_version).to eql(1.4)
     end
 
     it "should return the correct pdf_version" do
-      PDF::Reader.new(no_text_spaces).pdf_version.should eql(1.4)
+      expect(PDF::Reader.new(no_text_spaces).pdf_version).to eql(1.4)
     end
   end
 
   describe "page_count()" do
     context "with cairo-basic" do
       it "should return the correct page_count" do
-        PDF::Reader.new(cairo_basic).page_count.should eql(2)
+        expect(PDF::Reader.new(cairo_basic).page_count).to eql(2)
       end
     end
 
     context "with no_text_spaces" do
       it "should return the correct page_count" do
-        PDF::Reader.new(no_text_spaces).page_count.should eql(6)
+        expect(PDF::Reader.new(no_text_spaces).page_count).to eql(6)
       end
     end
 
     context "with indirect_page_count" do
       it "should return the correct page_count" do
-        PDF::Reader.new(pdf_spec_file("indirect_page_count")).page_count.should eql(1)
+        expect(PDF::Reader.new(pdf_spec_file("indirect_page_count")).page_count).to eql(1)
       end
     end
   end
@@ -50,54 +50,54 @@ describe PDF::Reader do
     it "should return the correct info hash from cairo-basic" do
       info = PDF::Reader.new(cairo_basic).info
 
-      info.size.should eql(2)
-      info[:Creator].should eql("cairo 1.4.6 (http://cairographics.org)")
-      info[:Producer].should eql("cairo 1.4.6 (http://cairographics.org)")
+      expect(info.size).to eql(2)
+      expect(info[:Creator]).to eql("cairo 1.4.6 (http://cairographics.org)")
+      expect(info[:Producer]).to eql("cairo 1.4.6 (http://cairographics.org)")
     end
 
     it "should return the correct info hash from no_text_spaces" do
       info = PDF::Reader.new(no_text_spaces).info
 
-      info.size.should eql(9)
+      expect(info.size).to eql(9)
     end
 
     it "should return the correct info hash from a file with utf-16 encoded info" do
       info = PDF::Reader.new(oo3).info
 
-      info.size.should eql(3)
-      info[:Creator].should  eql "Writer"
-      info[:Producer].should eql "OpenOffice.org 3.2"
-      info[:CreationDate].should eql "D:20101113071546-06'00'"
+      expect(info.size).to eql(3)
+      expect(info[:Creator]).to  eql "Writer"
+      expect(info[:Producer]).to eql "OpenOffice.org 3.2"
+      expect(info[:CreationDate]).to eql "D:20101113071546-06'00'"
     end
 
     if RUBY_VERSION >= "1.9.2"
       it "should return an info hash with strings marked as UTF-8" do
         info = PDF::Reader.new(oo3).info
 
-        info[:Creator].encoding.should      eql Encoding::UTF_8
-        info[:Producer].encoding.should     eql Encoding::UTF_8
-        info[:CreationDate].encoding.should eql Encoding::UTF_8
+        expect(info[:Creator].encoding).to      eql Encoding::UTF_8
+        expect(info[:Producer].encoding).to     eql Encoding::UTF_8
+        expect(info[:CreationDate].encoding).to eql Encoding::UTF_8
       end
     end
   end
 
   describe "metadata()" do
     it "should return nil metadata from cairo-basic" do
-      PDF::Reader.new(cairo_basic).metadata.should be_nil
+      expect(PDF::Reader.new(cairo_basic).metadata).to be_nil
     end
 
     it "should return the correct metadata from no_text_spaces" do
       metadata = PDF::Reader.new(no_text_spaces).metadata
 
-      metadata.should be_a_kind_of(String)
-      metadata.should include("<x:xmpmeta")
+      expect(metadata).to be_a_kind_of(String)
+      expect(metadata).to include("<x:xmpmeta")
     end
 
     if RUBY_VERSION >= "1.9.2"
       it "should return the metadata string marked as UTF-8" do
         metadata = PDF::Reader.new(no_text_spaces).metadata
 
-        metadata.encoding.should eql Encoding::UTF_8
+        expect(metadata.encoding).to eql Encoding::UTF_8
       end
     end
   end
@@ -106,31 +106,31 @@ describe PDF::Reader do
     it "should return an array of pages from cairo-basic" do
       pages = PDF::Reader.new(cairo_basic).pages
 
-      pages.should be_a_kind_of(Array)
-      pages.size.should eql(2)
+      expect(pages).to be_a_kind_of(Array)
+      expect(pages.size).to eql(2)
       pages.each do |page|
-        page.should be_a_kind_of(PDF::Reader::Page)
+        expect(page).to be_a_kind_of(PDF::Reader::Page)
       end
     end
 
     it "should return an array of pages from no_text_spaces" do
       pages = PDF::Reader.new(no_text_spaces).pages
 
-      pages.should be_a_kind_of(Array)
-      pages.size.should eql(6)
+      expect(pages).to be_a_kind_of(Array)
+      expect(pages.size).to eql(6)
       pages.each do |page|
-        page.should be_a_kind_of(PDF::Reader::Page)
+        expect(page).to be_a_kind_of(PDF::Reader::Page)
       end
     end
   end
 
   describe "page()" do
     it "should return a single page from cairo-basic" do
-      PDF::Reader.new(cairo_basic).page(1).should be_a_kind_of(PDF::Reader::Page)
+      expect(PDF::Reader.new(cairo_basic).page(1)).to be_a_kind_of(PDF::Reader::Page)
     end
 
     it "should return a single page from no_text_spaces" do
-      PDF::Reader.new(no_text_spaces).page(1).should be_a_kind_of(PDF::Reader::Page)
+      expect(PDF::Reader.new(no_text_spaces).page(1)).to be_a_kind_of(PDF::Reader::Page)
     end
   end
 

--- a/spec/reference_spec.rb
+++ b/spec/reference_spec.rb
@@ -8,7 +8,7 @@ describe PDF::Reader::Reference, "hash method" do
     one = PDF::Reader::Reference.new(1,0)
     two = PDF::Reader::Reference.new(1,0)
 
-    one.hash.should == two.hash
+    expect(one.hash).to eq(two.hash)
   end
 
 end
@@ -18,20 +18,20 @@ describe PDF::Reader::Reference, "== method" do
   it "should return true for the same object" do
     one = PDF::Reader::Reference.new(1,0)
 
-    (one == one).should be_true
+    expect(one == one).to be_truthy
   end
 
   it "should return true for 2 identical objects" do
     one = PDF::Reader::Reference.new(1,0)
     two = PDF::Reader::Reference.new(1,0)
 
-    (one == two).should be_true
+    expect(one == two).to be_truthy
   end
 
   it "should return false if one object isn't a Reference" do
     one = PDF::Reader::Reference.new(1,0)
 
-    (one == "two").should be_false
+    expect(one == "two").to be_falsey
   end
 
 end

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -11,8 +11,8 @@ describe PDF::Reader::Stream do
     io    = File.new(pdf_spec_file("pdfwriter-manual"))
     ohash = PDF::Reader::ObjectHash.new(io)
     obj   = ohash.object(PDF::Reader::Reference.new(7, 0))
-    obj.should be_a_kind_of(PDF::Reader::Stream)
-    obj.unfiltered_data.should eql(binary_string(decoded_stream))
+    expect(obj).to be_a_kind_of(PDF::Reader::Stream)
+    expect(obj.unfiltered_data).to eql(binary_string(decoded_stream))
   end
 
   it "should be able to decode streams that use FlateDecode with something funny about them"
@@ -90,7 +90,7 @@ EOF
       ohash = PDF::Reader::ObjectHash.new(io)
       ref   = PDF::Reader::Reference.new(30,0)
       obj   = ohash.object(ref)
-      lambda { obj.unfiltered_data }.should raise_error(PDF::Reader::MalformedPDFError)
+      expect { obj.unfiltered_data }.to raise_error(PDF::Reader::MalformedPDFError)
 
       # TODO: resolve why the zlib shippedwith ruby can't decompress this stream correctly
       #       then replace the the above raise_error check with the following 2 checks

--- a/spec/support/duck_types/width_calculator.rb
+++ b/spec/support/duck_types/width_calculator.rb
@@ -5,6 +5,6 @@
 
 shared_examples "a WidthCalculator duck type" do
   it "should implement the glyph_width method" do
-    subject.should respond_to(:glyph_width)
+    expect(subject).to respond_to(:glyph_width)
   end
 end

--- a/spec/syncronized_cache_spec.rb
+++ b/spec/syncronized_cache_spec.rb
@@ -17,7 +17,7 @@ describe PDF::Reader::SynchronizedCache, "#[]" do
 
   it "should return a stored value" do
     cache[:foo] = :bar
-    cache[:foo].should == :bar
+    expect(cache[:foo]).to eq(:bar)
   end
 
 end

--- a/spec/text_run_spec.rb
+++ b/spec/text_run_spec.rb
@@ -13,23 +13,23 @@ describe PDF::Reader::TextRun, "#initilize" do
     subject { PDF::Reader::TextRun.new(x, y, width, font, text)}
 
     it "should make x accessible" do
-      subject.x.should == 10
+      expect(subject.x).to eq(10)
     end
 
     it "should make y accessible" do
-      subject.y.should == 20
+      expect(subject.y).to eq(20)
     end
 
     it "should make width accessible" do
-      subject.width.should == 30
+      expect(subject.width).to eq(30)
     end
 
     it "should make font_size accessible" do
-      subject.font_size.should == 12
+      expect(subject.font_size).to eq(12)
     end
 
     it "should make text accessible" do
-      subject.text.should == "Chunky"
+      expect(subject.text).to eq("Chunky")
     end
   end
 end
@@ -45,7 +45,7 @@ describe PDF::Reader::TextRun, "#endx" do
     subject { PDF::Reader::TextRun.new(x, y, width, font, text)}
 
     it "should equal x + width" do
-      subject.endx.should == 40
+      expect(subject.endx).to eq(40)
     end
   end
 end
@@ -62,7 +62,7 @@ describe PDF::Reader::TextRun, "#mergable?" do
       let(:two)   { PDF::Reader::TextRun.new(one.endx+12, y, width, font, "B")}
 
       it "should return true" do
-        one.mergable?(two).should be_true
+        expect(one.mergable?(two)).to be_truthy
       end
     end
 
@@ -71,7 +71,7 @@ describe PDF::Reader::TextRun, "#mergable?" do
       let(:two)   { PDF::Reader::TextRun.new(one.endx+13, y, width, font, "B")}
 
       it "should return false" do
-        one.mergable?(two).should be_false
+        expect(one.mergable?(two)).to be_falsey
       end
     end
 
@@ -80,7 +80,7 @@ describe PDF::Reader::TextRun, "#mergable?" do
       let(:two)   { PDF::Reader::TextRun.new(x, y + 1, width, font, "B")}
 
       it "should return false" do
-        one.mergable?(two).should be_false
+        expect(one.mergable?(two)).to be_falsey
       end
     end
   end
@@ -90,7 +90,7 @@ describe PDF::Reader::TextRun, "#mergable?" do
       let(:two)   { PDF::Reader::TextRun.new(one.endx+12, y, width, font+1, "B")}
 
       it "should return true" do
-        one.mergable?(two).should be_false
+        expect(one.mergable?(two)).to be_falsey
       end
     end
 
@@ -99,7 +99,7 @@ describe PDF::Reader::TextRun, "#mergable?" do
       let(:two)   { PDF::Reader::TextRun.new(one.endx+13, y, width, font+1, "B")}
 
       it "should return false" do
-        one.mergable?(two).should be_false
+        expect(one.mergable?(two)).to be_falsey
       end
     end
 
@@ -108,7 +108,7 @@ describe PDF::Reader::TextRun, "#mergable?" do
       let(:two)   { PDF::Reader::TextRun.new(x, y + 1, width, font+1, "B")}
 
       it "should return false" do
-        one.mergable?(two).should be_false
+        expect(one.mergable?(two)).to be_falsey
       end
     end
   end
@@ -126,10 +126,10 @@ describe PDF::Reader::TextRun, "#+" do
 
     it "should return a new TextRun with combined data" do
       result = one + two
-      result.x.should     == 10
-      result.y.should     == 20
-      result.width.should == 61.2
-      result.text.should  == "AB"
+      expect(result.x).to     eq(10)
+      expect(result.y).to     eq(20)
+      expect(result.width).to eq(61.2)
+      expect(result.text).to  eq("AB")
     end
   end
 
@@ -139,10 +139,10 @@ describe PDF::Reader::TextRun, "#+" do
 
     it "should return a new TextRun with combined data" do
       result = one + two
-      result.x.should     == 10
-      result.y.should     == 20
-      result.width.should == 72
-      result.text.should  == "A B"
+      expect(result.x).to     eq(10)
+      expect(result.y).to     eq(20)
+      expect(result.width).to eq(72)
+      expect(result.text).to  eq("A B")
     end
   end
 
@@ -151,9 +151,9 @@ describe PDF::Reader::TextRun, "#+" do
     let(:two)   { PDF::Reader::TextRun.new(one.endx+13, y, width, font, "B")}
 
     it "should raise an exception" do
-      lambda {
+      expect {
         one + two
-      }.should raise_error(ArgumentError)
+      }.to raise_error(ArgumentError)
     end
   end
 end
@@ -168,7 +168,7 @@ describe PDF::Reader::TextRun, "#<=>" do
     let!(:two) { PDF::Reader::TextRun.new(10, 20, width, font, text)}
 
     it "should return 0" do
-      (one <=> two).should == 0
+      expect(one <=> two).to eq(0)
     end
   end
 
@@ -177,7 +177,7 @@ describe PDF::Reader::TextRun, "#<=>" do
     let!(:two) { PDF::Reader::TextRun.new(10, 20, width, font, text)}
 
     it "should sort two before one" do
-      [one, two].sort.should == [two, one]
+      expect([one, two].sort).to eq([two, one])
     end
   end
 
@@ -186,7 +186,7 @@ describe PDF::Reader::TextRun, "#<=>" do
     let!(:two) { PDF::Reader::TextRun.new(20, 10, width, font, text)}
 
     it "should sort one before two" do
-      [one, two].sort.should == [one, two]
+      expect([one, two].sort).to eq([one, two])
     end
   end
 
@@ -195,7 +195,7 @@ describe PDF::Reader::TextRun, "#<=>" do
     let!(:two) { PDF::Reader::TextRun.new(10, 05, width, font, text)}
 
     it "should sort one before two" do
-      [one, two].sort.should == [one, two]
+      expect([one, two].sort).to eq([one, two])
     end
   end
 
@@ -204,7 +204,7 @@ describe PDF::Reader::TextRun, "#<=>" do
     let!(:two) { PDF::Reader::TextRun.new(5, 10, width, font, text)}
 
     it "should sort two before one" do
-      [one, two].sort.should == [two, one]
+      expect([one, two].sort).to eq([two, one])
     end
   end
 
@@ -219,7 +219,7 @@ describe PDF::Reader::TextRun, "#mean_character_width" do
     subject { PDF::Reader::TextRun.new(10, 20, width, font, text)}
 
     it "should return 5.0" do
-      subject.mean_character_width.should == 5.0
+      expect(subject.mean_character_width).to eq(5.0)
     end
   end
 end

--- a/spec/transformation_matrix_spec.rb
+++ b/spec/transformation_matrix_spec.rb
@@ -25,13 +25,13 @@ describe PDF::Reader::TransformationMatrix, "#multiply!" do
       it "should leave the values unchanged" do
         matrix_one.multiply_with_an_object!(matrix_two)
 
-        matrix_one.to_a.should == [2,3,0,  4,5,0,  6,7,1]
+        expect(matrix_one.to_a).to eq([2,3,0,  4,5,0,  6,7,1])
       end
 
       it "should leave the values unchanged when reversed" do
         matrix_two.multiply_with_an_object!(matrix_one)
 
-        matrix_two.to_a.should == [2,3,0,  4,5,0,  6,7,1]
+        expect(matrix_two.to_a).to eq([2,3,0,  4,5,0,  6,7,1])
       end
     end
 
@@ -41,13 +41,13 @@ describe PDF::Reader::TransformationMatrix, "#multiply!" do
       it "should set the new matrix values" do
         matrix_one.multiply_with_an_object!(matrix_two)
 
-        matrix_one.to_a.should == [2,3,0,  4,5,0,  16,7,1]
+        expect(matrix_one.to_a).to eq([2,3,0,  4,5,0,  16,7,1])
       end
 
       it "should set the new matrix values when reversed" do
         matrix_two.multiply_with_an_object!(matrix_one)
 
-        matrix_two.to_a.should == [2,3,0,  4,5,0,  26,37,1]
+        expect(matrix_two.to_a).to eq([2,3,0,  4,5,0,  26,37,1])
       end
     end
 
@@ -57,13 +57,13 @@ describe PDF::Reader::TransformationMatrix, "#multiply!" do
       it "should set the new matrix values" do
         matrix_one.multiply_with_an_object!(matrix_two)
 
-        matrix_one.to_a.should == [2,3,0,  4,5,0,  6,17,1]
+        expect(matrix_one.to_a).to eq([2,3,0,  4,5,0,  6,17,1])
       end
 
       it "should set the new matrix values when reversed" do
         matrix_two.multiply_with_an_object!(matrix_one)
 
-        matrix_two.to_a.should == [2,3,0,  4,5,0,  46,57,1]
+        expect(matrix_two.to_a).to eq([2,3,0,  4,5,0,  46,57,1])
       end
     end
 
@@ -73,13 +73,13 @@ describe PDF::Reader::TransformationMatrix, "#multiply!" do
       it "should set the new matrix values" do
         matrix_one.multiply_with_an_object!(matrix_two)
 
-        matrix_one.to_a.should == [2,3,0,  4,5,0,  16,17,1]
+        expect(matrix_one.to_a).to eq([2,3,0,  4,5,0,  16,17,1])
       end
 
       it "should set the new matrix values when reversed" do
         matrix_two.multiply_with_an_object!(matrix_one)
 
-        matrix_two.to_a.should == [2,3,0,  4,5,0,  66,87,1]
+        expect(matrix_two.to_a).to eq([2,3,0,  4,5,0,  66,87,1])
       end
     end
 
@@ -89,13 +89,13 @@ describe PDF::Reader::TransformationMatrix, "#multiply!" do
       it "should set the new matrix values" do
         matrix_one.multiply_with_an_object!(matrix_two)
 
-        matrix_one.to_a.should == [20,3,0,  40,5,0,  60,7,1]
+        expect(matrix_one.to_a).to eq([20,3,0,  40,5,0,  60,7,1])
       end
 
       it "should set the new matrix values when reversed" do
         matrix_two.multiply_with_an_object!(matrix_one)
 
-        matrix_two.to_a.should == [20,30,0,  4,5,0,  6,7,1]
+        expect(matrix_two.to_a).to eq([20,30,0,  4,5,0,  6,7,1])
       end
     end
 
@@ -105,13 +105,13 @@ describe PDF::Reader::TransformationMatrix, "#multiply!" do
       it "should set the new matrix values" do
         matrix_one.multiply_with_an_object!(matrix_two)
 
-        matrix_one.to_a.should == [2,30,0,  4,50,0,  6,70,1]
+        expect(matrix_one.to_a).to eq([2,30,0,  4,50,0,  6,70,1])
       end
 
       it "should set the new matrix values when reversed" do
         matrix_two.multiply_with_an_object!(matrix_one)
 
-        matrix_two.to_a.should == [2,3,0,  40,50,0,  6,7,1]
+        expect(matrix_two.to_a).to eq([2,3,0,  40,50,0,  6,7,1])
       end
     end
 
@@ -121,13 +121,13 @@ describe PDF::Reader::TransformationMatrix, "#multiply!" do
       it "should set the new matrix values" do
         matrix_one.multiply_with_an_object!(matrix_two)
 
-        matrix_one.to_a.should == [20,30,0,  40,50,0,  60,70,1]
+        expect(matrix_one.to_a).to eq([20,30,0,  40,50,0,  60,70,1])
       end
 
       it "should set the new matrix values when reversed" do
         matrix_two.multiply_with_an_object!(matrix_one)
 
-        matrix_two.to_a.should == [20,30,0,  40,50,0,  6,7,1]
+        expect(matrix_two.to_a).to eq([20,30,0,  40,50,0,  6,7,1])
       end
     end
 
@@ -144,24 +144,24 @@ describe PDF::Reader::TransformationMatrix, "#multiply!" do
         matrix_one.multiply_with_an_object!(matrix_two)
 
         # we can't use #to_a in this test because of all the floating point nums
-        ( "%.3f" % matrix_one.a).should ==  "3.273"
-        ( "%.3f" % matrix_one.b).should == "-1.513"
-        ( "%.3f" % matrix_one.c).should ==  "5.557"
-        ( "%.3f" % matrix_one.d).should == "-3.181"
-        ( "%.3f" % matrix_one.e).should ==  "7.842"
-        ( "%.3f" % matrix_one.f).should == "-4.848"
+        expect( "%.3f" % matrix_one.a).to eq("3.273")
+        expect( "%.3f" % matrix_one.b).to eq("-1.513")
+        expect( "%.3f" % matrix_one.c).to eq("5.557")
+        expect( "%.3f" % matrix_one.d).to eq("-3.181")
+        expect( "%.3f" % matrix_one.e).to eq("7.842")
+        expect( "%.3f" % matrix_one.f).to eq("-4.848")
       end
 
       it "should set the new matrix values when reversed" do
         matrix_two.multiply_with_an_object!(matrix_one)
 
         # we can't use #to_a in this test because of all the floating point nums
-        ( "%.3f" % matrix_two.a).should == "-3.644"
-        ( "%.3f" % matrix_two.b).should == "-4.477"
-        ( "%.3f" % matrix_two.c).should ==  "2.593"
-        ( "%.3f" % matrix_two.d).should ==  "3.735"
-        ( "%.3f" % matrix_two.e).should ==  "6.000"
-        ( "%.3f" % matrix_two.f).should ==  "7.000"
+        expect( "%.3f" % matrix_two.a).to eq("-3.644")
+        expect( "%.3f" % matrix_two.b).to eq("-4.477")
+        expect( "%.3f" % matrix_two.c).to eq("2.593")
+        expect( "%.3f" % matrix_two.d).to eq("3.735")
+        expect( "%.3f" % matrix_two.e).to eq("6.000")
+        expect( "%.3f" % matrix_two.f).to eq("7.000")
       end
     end
   end
@@ -178,7 +178,7 @@ describe PDF::Reader::TransformationMatrix, "#horizontal_displacement_multiply!"
       it "should set the new matrix values" do
         matrix_one.horizontal_displacement_multiply!(displacement)
 
-        matrix_one.to_a.should == [2,3,0,  4,5,0,  16,7,1]
+        expect(matrix_one.to_a).to eq([2,3,0,  4,5,0,  16,7,1])
       end
 
     end

--- a/spec/width_calculator/built_in_spec.rb
+++ b/spec/width_calculator/built_in_spec.rb
@@ -14,9 +14,9 @@ describe PDF::Reader::WidthCalculator::BuiltIn, "#initialize" do
     let!(:font)        { double(:basefont => :Helvetica) }
 
     it "should initialize with no errors" do
-      lambda {
+      expect {
         PDF::Reader::WidthCalculator::BuiltIn.new(font)
-      }.should_not raise_error
+      }.not_to raise_error
     end
   end
 
@@ -24,9 +24,9 @@ describe PDF::Reader::WidthCalculator::BuiltIn, "#initialize" do
     let!(:font)        { double(:basefont => :Foo) }
 
     it "should raise an error" do
-      lambda {
+      expect {
         PDF::Reader::WidthCalculator::BuiltIn.new(font)
-      }.should raise_error(ArgumentError)
+      }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/width_calculator/composite_spec.rb
+++ b/spec/width_calculator/composite_spec.rb
@@ -20,12 +20,12 @@ describe PDF::Reader::WidthCalculator::Composite, "#glyph_width" do
 
     context "when the glyph code is provided in cid_widths" do
       it "should return the correct width" do
-        subject.glyph_width(10).should == 30
+        expect(subject.glyph_width(10)).to eq(30)
       end
     end
     context "when the glyph code is equal to greater than font#first_char" do
       it "should return the default width" do
-        subject.glyph_width(9).should == 50
+        expect(subject.glyph_width(9)).to eq(50)
       end
     end
   end

--- a/spec/width_calculator/true_type_spec.rb
+++ b/spec/width_calculator/true_type_spec.rb
@@ -22,12 +22,12 @@ describe PDF::Reader::WidthCalculator::TrueType, "#glyph_width" do
 
     context "when the glyph code is less than font#first_char" do
       it "should return the missing width" do
-        subject.glyph_width(9).should == 50
+        expect(subject.glyph_width(9)).to eq(50)
       end
     end
     context "when the glyph code is equal to greater than font#first_char" do
       it "should return the correct width" do
-        subject.glyph_width(10).should == 20
+        expect(subject.glyph_width(10)).to eq(20)
       end
     end
   end
@@ -41,7 +41,7 @@ describe PDF::Reader::WidthCalculator::TrueType, "#glyph_width" do
     subject           { PDF::Reader::WidthCalculator::TrueType.new(font)}
 
     it "should fetch the width from the descriptor" do
-      subject.glyph_width(10).should == 60
+      expect(subject.glyph_width(10)).to eq(60)
     end
   end
 end

--- a/spec/width_calculator/type_one_or_three_spec.rb
+++ b/spec/width_calculator/type_one_or_three_spec.rb
@@ -22,12 +22,12 @@ describe PDF::Reader::WidthCalculator::TypeOneOrThree, "#glyph_width" do
 
     context "when the glyph code is less than font#first_char" do
       it "should return the missing width" do
-        subject.glyph_width(9).should == 50
+        expect(subject.glyph_width(9)).to eq(50)
       end
     end
     context "when the glyph code is equal to greater than font#first_char" do
       it "should return the correct width" do
-        subject.glyph_width(10).should == 20
+        expect(subject.glyph_width(10)).to eq(20)
       end
     end
   end
@@ -39,7 +39,7 @@ describe PDF::Reader::WidthCalculator::TypeOneOrThree, "#glyph_width" do
     subject           { PDF::Reader::WidthCalculator::TypeOneOrThree.new(font)}
 
     it "should return 0" do
-      subject.glyph_width(10).should == 0
+      expect(subject.glyph_width(10)).to eq(0)
     end
   end
 end

--- a/spec/width_calculator/type_zero_spec.rb
+++ b/spec/width_calculator/type_zero_spec.rb
@@ -17,7 +17,7 @@ describe PDF::Reader::WidthCalculator::TypeZero, "#glyph_width" do
     subject            { PDF::Reader::WidthCalculator::TypeZero.new(font)}
 
     it "should delegate the width calculation to the first descendant font" do
-      subject.glyph_width(10).should == 50
+      expect(subject.glyph_width(10)).to eq(50)
     end
   end
 end

--- a/spec/xref_spec.rb
+++ b/spec/xref_spec.rb
@@ -12,24 +12,24 @@ describe PDF::Reader::XRef, "initilisation" do
     it "should load all xrefs correctly from a File" do
       filename = File.new(pdf_spec_file("cairo-basic"))
       tbl      = PDF::Reader::XRef.new(filename)
-      tbl.xref.keys.size.should eql(15) # 1 xref table with 16 items (ignore the first)
+      expect(tbl.xref.keys.size).to eql(15) # 1 xref table with 16 items (ignore the first)
     end
     it "should load all xrefs correctly from a StringIO" do
       data = StringIO.new(binread(pdf_spec_file("cairo-basic")))
       tbl  = PDF::Reader::XRef.new(data)
-      tbl.xref.keys.size.should eql(15) # 1 xref table with 16 items (ignore the first)
+      expect(tbl.xref.keys.size).to eql(15) # 1 xref table with 16 items (ignore the first)
     end
   end
   context "with cairo-unicode.pdf" do
     it "should load all xrefs correctly" do
       file = File.new(pdf_spec_file("cairo-unicode"))
       tbl  = PDF::Reader::XRef.new(file)
-      tbl.xref.keys.size.should eql(57) # 1 xref table with 58 items (ignore the first)
+      expect(tbl.xref.keys.size).to eql(57) # 1 xref table with 58 items (ignore the first)
     end
     it "should load all xrefs correctly from a StringIO" do
       data = StringIO.new(binread(pdf_spec_file("cairo-unicode")))
       tbl  = PDF::Reader::XRef.new(data)
-      tbl.xref.keys.size.should eql(57) # 1 xref table with 58 items (ignore the first)
+      expect(tbl.xref.keys.size).to eql(57) # 1 xref table with 58 items (ignore the first)
     end
   end
 
@@ -37,7 +37,7 @@ describe PDF::Reader::XRef, "initilisation" do
     it "should load all xrefs correctly" do
       @file = File.new(pdf_spec_file("openoffice-2.2"))
       @tbl = PDF::Reader::XRef.new(@file)
-      @tbl.xref.keys.size.should eql(28) # 1 xref table with 29 items (ignore the first)
+      expect(@tbl.xref.keys.size).to eql(28) # 1 xref table with 29 items (ignore the first)
     end
   end
 
@@ -45,7 +45,7 @@ describe PDF::Reader::XRef, "initilisation" do
     it "should load all xrefs correctly" do
       @file = File.new(pdf_spec_file("pdflatex"))
       @tbl = PDF::Reader::XRef.new(@file)
-      @tbl.xref.keys.size.should eql(353) # 1 xref table with 360 items (but a bunch are ignored)
+      expect(@tbl.xref.keys.size).to eql(353) # 1 xref table with 360 items (but a bunch are ignored)
     end
   end
 
@@ -53,25 +53,25 @@ describe PDF::Reader::XRef, "initilisation" do
     it "should load all xrefs correctly from a PDF that has multiple xref sections with subsections and xref streams" do
       @file = File.new(pdf_spec_file("xref_subsections"))
       @tbl = PDF::Reader::XRef.new(@file)
-      @tbl.xref.keys.size.should eql(539)
+      expect(@tbl.xref.keys.size).to eql(539)
     end
   end
 
   context "with no_trailer.pdf" do
     it "should raise an error when attempting to locate the xref table" do
       @file = File.new(pdf_spec_file("no_trailer"))
-      lambda {
+      expect {
         PDF::Reader::XRef.new(@file)
-      }.should raise_error(PDF::Reader::MalformedPDFError)
+      }.to raise_error(PDF::Reader::MalformedPDFError)
     end
   end
 
   context "with trailer_is_not_a_dict.pdf" do
     it "should raise an error when attempting to locate the xref table" do
       @file = File.new(pdf_spec_file("trailer_is_not_a_dict"))
-      lambda {
+      expect {
         PDF::Reader::XRef.new(@file)
-      }.should raise_error(PDF::Reader::MalformedPDFError)
+      }.to raise_error(PDF::Reader::MalformedPDFError)
     end
   end
 
@@ -80,15 +80,15 @@ describe PDF::Reader::XRef, "initilisation" do
     subject     { PDF::Reader::XRef.new(file)}
 
     it "should correctly load all object locations" do
-      subject.xref.keys.size.should eql(327) # 1 xref stream with 344 items (ignore the 17 free objects)
+      expect(subject.xref.keys.size).to eql(327) # 1 xref stream with 344 items (ignore the 17 free objects)
     end
 
     it "should load type 1 objects references" do
-      subject.xref[66][0].should eql(298219)
+      expect(subject.xref[66][0]).to eql(298219)
     end
 
     it "should load type 2 objects references" do
-      subject.xref[281][0].should eql(PDF::Reader::Reference.new(341,0))
+      expect(subject.xref[281][0]).to eql(PDF::Reader::Reference.new(341,0))
     end
   end
 
@@ -97,9 +97,9 @@ describe PDF::Reader::XRef, "initilisation" do
     subject     { PDF::Reader::XRef.new(file)}
 
     it "should raise an error when attempting to load an invalid xref stream" do
-      lambda do
+      expect do
         subject.send(:load_xref_stream, {:Subject=>"\xFE\xFF"})
-      end.should raise_exception(PDF::Reader::MalformedPDFError)
+      end.to raise_exception(PDF::Reader::MalformedPDFError)
     end
   end
 
@@ -108,8 +108,8 @@ describe PDF::Reader::XRef, "initilisation" do
     subject     { PDF::Reader::XRef.new(file)}
 
     it "should ignore non-free entries in the xref stream that point to offset 0" do
-      subject.size.should eql(6)
-      subject.xref.keys.should_not include(7)
+      expect(subject.size).to eql(6)
+      expect(subject.xref.keys).not_to include(7)
     end
   end
 
@@ -117,15 +117,15 @@ describe PDF::Reader::XRef, "initilisation" do
     it "should load all xrefs correctly from a File" do
       File.open(pdf_spec_file("junk_prefix")) do |file|
         tbl      = PDF::Reader::XRef.new(file)
-        tbl.xref.keys.size.should eql(6) # 1 xref table with 6 items (ignore the first)
+        expect(tbl.xref.keys.size).to eql(6) # 1 xref table with 6 items (ignore the first)
       end
     end
 
     it "should load all xrefs with an offset to skip junk at the beginning of the file" do
       File.open(pdf_spec_file("junk_prefix")) do |file|
         tbl      = PDF::Reader::XRef.new(file)
-        tbl.xref[1][0].should == 36
-        tbl.xref[2][0].should == 130
+        expect(tbl.xref[1][0]).to eq(36)
+        expect(tbl.xref[2][0]).to eq(130)
       end
     end
   end


### PR DESCRIPTION
Convert specs to RSpec 2.99.2 syntax with Transpec

This conversion is done by Transpec 3.1.1 with the following command:
    transpec

* 950 conversions
    from: obj.should
      to: expect(obj).to

* 270 conversions
    from: == expected
      to: eq(expected)

* 27 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 18 conversions
    from: lambda { }.should
      to: expect { }.to

* 17 conversions
    from: be_false
      to: be_falsey

* 12 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 10 conversions
    from: be_true
      to: be_truthy

* 7 conversions
    from: =~ /pattern/
      to: match(/pattern/)

* 6 conversions
    from: mock('something')
      to: double('something')

* 5 conversions
    from: stub('something')
      to: double('something')

* 2 conversions
    from: lambda { }.should_not
      to: expect { }.not_to

* 2 conversions
    from: pending 'is an example' { }
      to: skip 'is an example' { }

* 1 conversion
    from: it { should ... }
      to: it { is_expected.to ... }

* 1 conversion
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 1 conversion
    from: pending
      to: skip

For more details: https://github.com/yujinakayama/transpec#supported-conversions

Additional fix:

http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/
 -> Assertion config changes

"For RSpec 3, we've removed expect_with :stdlib and instead
opted for explicit :test_unit and :minitest options:"

:stdlib is no longer a valid option, so changing it to :minitest