### PR TITLE
Officially support MRI 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,3 @@ rvm:
   - 2.3.0-preview1
   - rbx-19mode
   - jruby-19mode
-
-matrix:
-  allow_failures:
-    - rvm: 2.2
-    - rvm: 2.3.0-preview1

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("morecane")
   spec.add_development_dependency("ir_b")
   spec.add_development_dependency("rdoc")
-  spec.add_development_dependency("minitest")
 
   spec.add_dependency('Ascii85', '~> 1.0.0')
   spec.add_dependency('ruby-rc4')

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("morecane")
   spec.add_development_dependency("ir_b")
   spec.add_development_dependency("rdoc")
+  spec.add_development_dependency("minitest")
 
   spec.add_dependency('Ascii85', '~> 1.0.0')
   spec.add_dependency('ruby-rc4')

--- a/spec/callback_spec.rb
+++ b/spec/callback_spec.rb
@@ -23,8 +23,8 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return a single float argument on #{filename}" do
         receiver.all_args(:pdf_version).each.each do |args|
-          assert_equal 1, args.size
-          assert args[0].is_a?(Float)
+          expect(args.size).to eq 1
+          expect(args[0]).to be_a(Float)
         end
       end
     end
@@ -34,8 +34,8 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return a single hash argument on #{filename}" do
         receiver.all_args(:metadata).each.each do |args|
-          assert_equal 1, args.size
-          assert args[0].is_a?(Hash)
+          expect(args.size).to eq 1
+          expect(args[0]).to be_a(Hash)
           check_utf8(args)
         end
       end
@@ -47,8 +47,8 @@ describe PDF::Reader do
       it "should return a single UTF-8 string argument on #{filename}" do
 
         receiver.all_args(:xml_metadata).each do |args|
-          assert_equal 1, args.size
-          assert args[0].is_a?(String)
+          expect(args.size).to eq 1
+          expect(args[0]).to be_a(String)
           check_utf8(args)
         end
 
@@ -61,9 +61,9 @@ describe PDF::Reader do
       it "should return a single Fixnum argument that is > 0 on #{filename}" do
 
         receiver.all_args(:page_count).each do |args|
-          assert_equal 1, args.size
-          assert args[0].is_a?(Fixnum)
-          (args[0] > 0).should  be_true
+          expect(args.size).to eq 1
+          expect(args[0]).to be_a(Fixnum)
+          expect(args[0] > 0).to  be_true
         end
 
       end
@@ -78,7 +78,7 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:begin_inline_image).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
       end
     end
@@ -88,9 +88,9 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return a Hash and binary string argument on #{filename}" do
         receiver.all_args(:begin_inline_image_data).each do |args|
-          assert_equal 2, args.size
-          assert args[0].is_a?(Hash)
-          assert args[1].is_a?(String)
+          expect(args.size).to eq 2
+          expect(args[0]).to be_a(Hash)
+          expect(args[1]).to be_a(String)
           check_utf8(args[0])
           check_binary(args[1])
         end
@@ -109,7 +109,7 @@ describe PDF::Reader do
             bytes_per_pixel = bits / 8.0
           end
           length = (width * height * bytes_per_pixel).to_i
-          assert_equal length, args[1].size
+          expect(args[1].size).to eq length
         end
 
       end
@@ -120,7 +120,7 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:begin_text_object).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
       end
     end
@@ -130,7 +130,7 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:end_document).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
       end
     end
@@ -141,7 +141,7 @@ describe PDF::Reader do
       it "should return no arguments on #{filename}" do
 
         receiver.all_args(:end_inline_image).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
 
       end
@@ -152,7 +152,7 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:end_page).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
       end
     end
@@ -162,7 +162,7 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:end_page_container).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
       end
     end
@@ -172,7 +172,7 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:end_text_object).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
       end
     end
@@ -182,8 +182,8 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return a single UTF-8 strings on #{filename}" do
         receiver.all_args(:move_to_next_line_and_show_text).each do |args|
-          assert_equal 1, args.size
-          assert args[0].is_a? String
+          expect(args.size).to eq 1
+          expect(args[0]).to be_a(String)
           check_utf8(args)
         end
       end
@@ -194,7 +194,7 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:restore_graphics_state).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
       end
     end
@@ -204,7 +204,7 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:save_graphics_state).each do |args|
-          assert_equal [], args
+          expect(args).to eq([])
         end
       end
     end
@@ -214,9 +214,9 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return no arguments on #{filename}" do
         receiver.all_args(:set_text_font_and_size).each do |args|
-          assert_equal 2, args.size
-          assert args[0].is_a? Symbol
-          assert args[1].is_a? Numeric
+          expect(args.size).to eq 2
+          expect(args[0]).to be_a(Symbol)
+          expect(args[1]).to be_a(Numeric)
         end
       end
     end
@@ -226,8 +226,8 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return a single UTF-8 string argument on #{filename}" do
         receiver.all_args(:show_text).each do |args|
-          assert_equal 1, args.size
-          assert args[0].is_a? String
+          expect(args.size).to eq 1
+          expect(args[0]).to be_a(String)
           check_utf8(args)
         end
       end
@@ -239,7 +239,7 @@ describe PDF::Reader do
       it "should return an array of Numbers and UTF-8 strings on #{filename}" do
         receiver.all_args(:show_text_with_positioning).each do |args|
           args[0].each do |arg|
-            assert arg.class == String || arg.class == Fixnum || arg.class == Float
+            expect(arg.class == String || arg.class == Fixnum || arg.class == Float).to eq true
           end
           check_utf8(args)
         end
@@ -251,10 +251,10 @@ describe PDF::Reader do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
       it "should return a single UTF-8 strings on #{filename}" do
         receiver.all_args(:set_spacing_next_line_show_text).each do |args|
-          assert_equal 3, args.size
-          assert args[0].is_a?(Numeric)
-          assert args[1].is_a?(Numeric)
-          assert args[2].is_a?(String)
+          expect(args.size).to eq 3
+          expect(args[0]).to be_a(Numeric)
+          expect(args[1]).to be_a(Numeric)
+          expect(args[2]).to be_a(String)
           check_utf8(args)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,6 @@ require 'digest/md5'
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 
 RSpec.configure do |config|
-  config.expect_with :rspec, :stdlib
+  config.expect_with :rspec, :minitest
   config.include ReaderSpecHelper
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,6 @@ require 'digest/md5'
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 
 RSpec.configure do |config|
-  config.expect_with :rspec, :minitest
+  config.expect_with :rspec
   config.include ReaderSpecHelper
 end

--- a/spec/support/encoding_helper.rb
+++ b/spec/support/encoding_helper.rb
@@ -21,8 +21,8 @@ module EncodingHelper
         check_utf8(value)
       }
     when String
-      assert_equal Encoding.find("utf-8"), obj.encoding
-      assert obj.valid_encoding?
+      expect(obj.encoding).to eq Encoding.find("utf-8")
+      expect(obj.valid_encoding?).to eq true
     else
       return
     end
@@ -43,8 +43,8 @@ module EncodingHelper
         check_utf8(value)
       }
     when String
-      assert_equal obj.encoding, Encoding.find("binary")
-      assert obj.valid_encoding?
+      expect(obj.encoding).to eq Encoding.find("binary")
+      expect(obj.valid_encoding?).to eq true
     else
       return
     end


### PR DESCRIPTION
Update the specs to pass on MRI 2.2. 

I've converted the few specs that used minitest to use vanilla rspec expectations.

They were originally added in commit aa2c270, with the justification that they dropped spec times from ~192s to ~34 seconds. Somewhere between then and now, that became less of an issue - possibly due to upgrading to rspec <strike>3</strike>2.99 or improvements to MRI.

On my current laptop with MRI 2.2.3, the spec/callback_spec.rb complete in < 8 seconds with both minitest and rspec, so we may as well standardise on rspec.