### PR TITLE
allow builds to fail on rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ rvm:
   - jruby-19mode
 before_install:
   - gem update bundler
+matrix:
+  - allow_failures:
+    - rvm: rbx-19mode


### PR DESCRIPTION
I'm interested in knowing if the build works on rubinius, but these days it's not used enough to make it worth failing the build