### PR TITLE
Fix few bugs in StandardSecurityHandler

### DIFF
--- a/lib/pdf/reader/standard_security_handler.rb
+++ b/lib/pdf/reader/standard_security_handler.rb
@@ -146,7 +146,7 @@ class PDF::Reader
         #initialize out for first iteration
         out = Digest::MD5.digest(PassPadBytes.pack("C*") + @file_id)
         #zero doesn't matter -> so from 0-19
-        20.times{ |i| out=RC4.new(xor_each_byte(keyBegins, i)).decrypt(out) }
+        20.times{ |i| out=RC4.new(xor_each_byte(keyBegins, i)).encrypt(out) }
         pass = @user_key[(0...16)] == out
       else
         pass = RC4.new(keyBegins).encrypt(PassPadBytes.pack("C*")) == @user_key
@@ -164,8 +164,8 @@ class PDF::Reader
       # e) add the file ID
       @buf << @file_id
       # f) if revision > 4 then if encryptMetadata add 4 bytes of 0x00 else add 4 bytes of 0xFF
-      if @revision > 4
-        @buf << [ @encryptMetadata ? 0x00 : 0xFF ].pack('C')*4
+      if @revision >= 4
+        @buf << [0xFF].pack('C')*4 unless @encryptMetadata
       end
       # b) init MD5 digest + g) finish the hash
       md5 = Digest::MD5.digest(@buf)


### PR DESCRIPTION
`StandardSecurityHandler` has two bugs that breaks the encrypted PDF file support

`lib/pdf/reader/standard_security_handler.rb`
- line 149 : see 7.6.3.4, Algorithm 5, step (d) - (e) of ISO 32000-1
- line 167-168 : see 7.6.3.3, Algorithm 2, step (f) of ISO 32000-1
