### PR TITLE
Fix inline image parsing: EI does not need prefixed whitespace

### DIFF
--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -227,7 +227,7 @@ class PDF::Reader
 
       buffer = []
 
-      until buffer[0] =~ /\s/ && buffer[1, 2] == ["E", "I"]
+      until buffer[0] =~ /\s|\0/ && buffer[1, 2] == ["E", "I"]
         chr = @io.read(1)
         buffer << chr
 
@@ -236,7 +236,9 @@ class PDF::Reader
         end
       end
 
-      @tokens << string_token(str.strip)
+      str << "\x00" if buffer.first == "\x00"
+
+      @tokens << string_token(str)
       @io.seek(-3, IO::SEEK_CUR) unless chr.nil?
     end
 

--- a/spec/buffer_spec.rb
+++ b/spec/buffer_spec.rb
@@ -369,6 +369,17 @@ describe PDF::Reader::Buffer, "token method" do
     expect(buf.token).to eql("EI")
   end
 
+  it "should correctly tokenise an inline image with no whitespace before the letters 'EI'" do
+    io = StringIO.new(binary_string("BI ID aaa bbb ccc \xF0\xF0\xF0\x00EI"))
+    buf = PDF::Reader::Buffer.new(io, :content_stream => true)
+
+    expect(buf.pos).to eql(0)
+    expect(buf.token).to eql("BI")
+    expect(buf.token).to eql("ID")
+    expect(buf.token).to eql(binary_string("aaa bbb ccc \xF0\xF0\xF0\x00"))
+    expect(buf.token).to eql("EI")
+  end
+
   it "should correctly tokenise a hash that has ID as a key" do
     io = StringIO.new("<</ID /S1 >> BDC")
     buf = PDF::Reader::Buffer.new(io, :content_stream => true)


### PR DESCRIPTION
I came across an interesting example of a PDF from my bank statement (very big bank).
An embedded image in the PDF looks like this:

```
BI\nID \x00\x00\x00\x00EI
```
(`EI` comes immediately after a null character)

As far as I can tell, there's no detail in the spec that says an
embedded image must be terminated with a whitespace character. Since
this PDF is parse-able, I think a simple fix can allow for this corner
case while sill allowing other examples where the "EI" string correctly
appears within the image (not a terminating token).

Due to the null character being appended (and a new corner case to make
sure this char is appended), I removed the "strip" call on the string
token. I traced through the commit history, but could not find a good
reason for why this "strip" call was added. Removing this did not cause
any specs to fail (which is not a great heuristic, but at least show
this might not actually be important). If it is important, then we can
at least parse the text correctly (which is good enough for me).

Resolves issue #169

My only concern is that this feels a little brittle. If you have any advice on how this can feel a bit nicer, please, don't hesitate to comment!

NOTE: I was referring to page 352 from the spec: http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_reference_1-7.pdf