### PR TITLE
look for `obj[:Kids]` instead of `obj[:Pages]`

### DIFF
--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -316,7 +316,7 @@ class PDF::Reader
 
       if obj[:Type] == :Page
         ref
-      elsif obj[:Type] == :Pages
+      elsif obj[:Kids]
         deref(obj[:Kids]).map { |kid| get_page_objects(kid) }
       end
     end


### PR DESCRIPTION
I ran across a PDF that raised this error when executing `PDF::Reader#pages`:

```
NoMethodError: undefined method `flatten' for nil:NilClass
File "/app/vendor/bundle/ruby/2.2.0/gems/pdf-reader-1.4.0/lib/pdf/reader/object_hash.rb" line 256 in page_references
File "/app/vendor/bundle/ruby/2.2.0/gems/pdf-reader-1.4.0/lib/pdf/reader/page.rb" line 35 in initialize
File "/app/vendor/bundle/ruby/2.2.0/gems/pdf-reader-1.4.0/lib/pdf/reader.rb" line 238 in new
File "/app/vendor/bundle/ruby/2.2.0/gems/pdf-reader-1.4.0/lib/pdf/reader.rb" line 238 in block in pages
File "/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.2/lib/active_support/core_ext/range/each.rb" line 7 in each
File "/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.2/lib/active_support/core_ext/range/each.rb" line 7 in each_with_time_with_zone
File "/app/vendor/bundle/ruby/2.2.0/gems/pdf-reader-1.4.0/lib/pdf/reader.rb" line 237 in map
File "/app/vendor/bundle/ruby/2.2.0/gems/pdf-reader-1.4.0/lib/pdf/reader.rb" line 237 in pages
```

I can't share the PDF, as it contains personal information, however, the structure of the file contains:

```
2 0 obj
<<
/Count 1 
/Kids [ 1 0 R ]
>>
endobj
...
11 0 obj
<<
/Lang (x-default) 
/Pages 2 0 R 
/Type /Catalog 
>>
endobj
...
trailer
<<
/Info 6 0 R 
/Prev 162205 
/Root 11 0 R 
/Size 57 
>>
```

I'm fairly certain that indirect object 2 is missing a `/Type` entry. Despite this, the PDF opens up just fine on my computer, so I'm not sure if this should raise an error or if the code should look for `obj[:Kids]` instead of `obj[:Pages]`. Using this fix, `PDF::Reader#pages` works as expected.
