### PR TITLE
Tokenize empty names that are next to delimiters.

### DIFF
--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -37,6 +37,7 @@ class PDF::Reader
   #
   class Buffer
     TOKEN_WHITESPACE=[0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20]
+    TOKEN_DELIMITER=[0x25, 0x3C, 0x3E, 0x28, 0x5B, 0x7B, 0x29, 0x5D, 0x7D, 0x2F]
 
     # some strings for comparissons. Declaring them here avoids creating new
     # strings that need GC over and over
@@ -366,7 +367,7 @@ class PDF::Reader
           # PDF name, start of new token
           @tokens << tok if tok.size > 0
           @tokens << byte.chr
-          @tokens << "" if byte == 0x2F && [nil, 0x20, 0x0A].include?(peek_byte)
+          @tokens << "" if byte == 0x2F && ([nil, 0x20, 0x0A].include?(peek_byte) || TOKEN_DELIMITER.include?(peek_byte))
           tok = ""
           break
         else

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -2,7 +2,7 @@
 # which will make the gem filesize irritatingly large
 Gem::Specification.new do |spec|
   spec.name = "pdf-reader"
-  spec.version = "1.4.0"
+  spec.version = "1.4.1"
   spec.summary = "A library for accessing the content of PDF files"
   spec.description = "The PDF::Reader library implements a PDF parser conforming as much as possible to the PDF specification from Adobe"
   spec.license = "MIT"

--- a/spec/buffer_spec.rb
+++ b/spec/buffer_spec.rb
@@ -43,6 +43,7 @@ describe PDF::Reader::Buffer, "token method" do
     expect(buf.token).to eql("[")
     expect(buf.token).to eql("{")
     expect(buf.token).to eql("/")
+    expect(buf.token).to eql("")  # auto adds empty name token
     expect(buf.token).to eql("(")
     expect(buf.token).to eql(")") # auto adds closing literal string delim
     expect(buf.token).to be_nil
@@ -103,6 +104,18 @@ describe PDF::Reader::Buffer, "token method" do
     expect(buf.token).to eql("")
     expect(buf.token).to eql("/")
     expect(buf.token).to eql("")
+    expect(buf.token).to be_nil
+  end
+
+  it "should correctly tokenize dict with an empty name" do
+    buf = parse_string("<</V/>>")
+
+    expect(buf.token).to eql("<<")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("V")
+    expect(buf.token).to eql("/")
+    expect(buf.token).to eql("")
+    expect(buf.token).to eql(">>")
     expect(buf.token).to be_nil
   end
 


### PR DESCRIPTION
Acrobat seems to sometimes serialize the value key in a form field as the empty name. Right now, this confuses the tokenizer, since it seems to only expect empty names to be followed by whitespace, but the actual PDF content is something along the lines of `<</V/>>`.

This appears to be a legal encoding of an empty name in a dictionary. From page 50 of the PDF 1.7 spec:

> The delimiter  characters (, ), <, >, [, ], {, }, /,  and % are special. They delimit syntactic  entities  such  as  strings,  arrays,  names,  and  comments.  Any  of  these characters terminates the entity preceding it and is not included in the entity. 

I've changed the tokenizer to produce an extra empty token in this case, since that appears to be how it was fixed for the whitespace cases. Let me know if I should edit how the `pdf_name` strategy uses the tokens instead.
