### PR TITLE
Fixes for Ruby 2.4 warnings and some other warnings

### DIFF
--- a/lib/pdf/reader.rb
+++ b/lib/pdf/reader.rb
@@ -285,7 +285,7 @@ module PDF
     #
     # Given an IO object that contains PDF data, return the contents of a single object
     #
-    def object (io, id, gen)
+    def object(io, id, gen)
       msg  = "PDF::Reader#object is deprecated and will be removed in the 2.0 release"
       $stderr.puts(msg)
       @objects = ObjectHash.new(io)

--- a/lib/pdf/reader/abstract_strategy.rb
+++ b/lib/pdf/reader/abstract_strategy.rb
@@ -23,7 +23,7 @@ class PDF::Reader
 
     # calls the name callback method on the receiver class with params as the arguments
     #
-    def callback (name, params=[])
+    def callback(name, params=[])
       @receivers.each do |receiver|
         receiver.send(name, *params) if receiver.respond_to?(name)
       end

--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -61,7 +61,7 @@ class PDF::Reader
     #   :content_stream - set to true if buffer will be tokenising a
     #                     content stream. Defaults to false
     #
-    def initialize (io, opts = {})
+    def initialize(io, opts = {})
       @io = io
       @tokens = []
       @in_content_stream = opts[:content_stream]

--- a/lib/pdf/reader/cmap.rb
+++ b/lib/pdf/reader/cmap.rb
@@ -68,11 +68,11 @@ class PDF::Reader
 
     # Convert a glyph code into one or more Codepoints.
     #
-    # Returns an array of Fixnums.
+    # Returns an array of Integers.
     #
     def decode(c)
       # TODO: implement the conversion
-      return c unless c.class == Fixnum
+      return c unless Integer === c
       @map[c]
     end
 

--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -210,7 +210,7 @@ class PDF::Reader
       RUBY_VERSION >= "1.9" ? mode = "r:BINARY" : mode = "r"
       File.open(file, mode) do |f|
         f.each do |l|
-          m, single_byte, unicode = *l.match(/([0-9A-Za-z]+);([0-9A-F]{4})/)
+          _m, single_byte, unicode = *l.match(/([0-9A-Za-z]+);([0-9A-F]{4})/)
           @mapping["0x#{single_byte}".hex] = "0x#{unicode}".hex if single_byte
         end
       end

--- a/lib/pdf/reader/error.rb
+++ b/lib/pdf/reader/error.rb
@@ -29,19 +29,19 @@ class PDF::Reader
   # are valid
   class Error # :nodoc:
     ################################################################################
-    def self.str_assert (lvalue, rvalue, chars=nil)
+    def self.str_assert(lvalue, rvalue, chars=nil)
       raise MalformedPDFError, "PDF malformed, expected string but found #{lvalue.class} instead" if chars and !lvalue.kind_of?(String)
       lvalue = lvalue[0,chars] if chars
       raise MalformedPDFError, "PDF malformed, expected '#{rvalue}' but found #{lvalue} instead"  if lvalue != rvalue
     end
     ################################################################################
-    def self.str_assert_not (lvalue, rvalue, chars=nil)
+    def self.str_assert_not(lvalue, rvalue, chars=nil)
       raise MalformedPDFError, "PDF malformed, expected string but found #{lvalue.class} instead" if chars and !lvalue.kind_of?(String)
       lvalue = lvalue[0,chars] if chars
       raise MalformedPDFError, "PDF malformed, expected '#{rvalue}' but found #{lvalue} instead"  if lvalue == rvalue
     end
     ################################################################################
-    def self.assert_equal (lvalue, rvalue)
+    def self.assert_equal(lvalue, rvalue)
       raise MalformedPDFError, "PDF malformed, expected #{rvalue} but found #{lvalue} instead" if lvalue != rvalue
     end
     ################################################################################

--- a/lib/pdf/reader/font.rb
+++ b/lib/pdf/reader/font.rb
@@ -161,15 +161,16 @@ class PDF::Reader
     end
 
     def to_utf8_via_cmap(params)
-      if params.class == Fixnum
+      case params
+      when Integer
         [
           @tounicode.decode(params) || PDF::Reader::Encoding::UNKNOWN_CHAR
         ].flatten.pack("U*")
-      elsif params.class == String
+      when String
         params.unpack(encoding.unpack).map { |c|
           @tounicode.decode(c) || PDF::Reader::Encoding::UNKNOWN_CHAR
         }.flatten.pack("U*")
-      elsif params.class == Array
+      when Array
         params.collect { |param| to_utf8_via_cmap(param) }
       else
         params
@@ -181,11 +182,12 @@ class PDF::Reader
         raise UnsupportedFeatureError, "font encoding '#{encoding}' currently unsupported"
       end
 
-      if params.class == Fixnum
+      case params
+      when Integer
         encoding.int_to_utf8_string(params)
-      elsif params.class == String
+      when String
         encoding.to_utf8(params)
-      elsif params.class == Array
+      when Array
         params.collect { |param| to_utf8_via_encoding(param) }
       else
         params

--- a/lib/pdf/reader/glyph_hash.rb
+++ b/lib/pdf/reader/glyph_hash.rb
@@ -105,7 +105,7 @@ class PDF::Reader
       RUBY_VERSION >= "1.9" ? mode = "r:BINARY" : mode = "r"
       File.open(File.dirname(__FILE__) + "/glyphlist.txt", mode) do |f|
         f.each do |l|
-          m, name, code = *l.match(/([0-9A-Za-z]+);([0-9A-F]{4})/)
+          _m, name, code = *l.match(/([0-9A-Za-z]+);([0-9A-F]{4})/)
           if name && code
             cp = "0x#{code}".hex
             keyed_by_name[name.to_sym]   = cp

--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -78,7 +78,7 @@ class PDF::Reader
 
       if @cache.has_key?(key)
         @cache[key]
-      elsif xref[key].is_a?(Fixnum)
+      elsif xref[key].is_a?(Integer)
         buf = new_buffer(xref[key])
         @cache[key] = decrypt(key, Parser.new(buf, self).object(key.id, key.gen))
       elsif xref[key].is_a?(PDF::Reader::Reference)

--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -323,7 +323,7 @@ class PDF::Reader
 
     def read_version
       @io.seek(0)
-      m, version = *@io.read(10).match(/PDF-(\d.\d)/)
+      _m, version = *@io.read(10).match(/PDF-(\d.\d)/)
       @io.seek(0)
       version.to_f
     end

--- a/lib/pdf/reader/page.rb
+++ b/lib/pdf/reader/page.rb
@@ -155,7 +155,7 @@ module PDF
 
       # calls the name callback method on each receiver object with params as the arguments
       #
-      def callback (receivers, name, params=[])
+      def callback(receivers, name, params=[])
         receivers.each do |receiver|
           receiver.send(name, *params) if receiver.respond_to?(name)
         end

--- a/lib/pdf/reader/page_state.rb
+++ b/lib/pdf/reader/page_state.rb
@@ -327,7 +327,6 @@ class PDF::Reader
           glyph_width = ((w0 - (tj/1000.0)) * fs) * th
           tx = glyph_width + ((tc + tw) * th)
         end
-        ty = 0
 
         # TODO: I'm pretty sure that tx shouldn't need to be divided by
         #       ctm[0] here, but this gets my tests green and I'm out of

--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -14,7 +14,7 @@ module PDF
 
       SPACE = " "
 
-      attr_reader :state, :content, :options
+      attr_reader :state, :options
 
       ########## BEGIN FORWARDERS ##########
       # Graphics State Operators

--- a/lib/pdf/reader/pages_strategy.rb
+++ b/lib/pdf/reader/pages_strategy.rb
@@ -282,7 +282,7 @@ class PDF::Reader
     ################################################################################
     # Walk over all pages in the PDF file, calling the appropriate callbacks for each page and all
     # its content
-    def walk_pages (page)
+    def walk_pages(page)
 
       # extract page content
       if page[:Type] == :Pages
@@ -351,7 +351,7 @@ class PDF::Reader
     # Reads a PDF content stream and calls all the appropriate callback methods for the operators
     # it contains
     #
-    def content_stream (instructions, fonts = {})
+    def content_stream(instructions, fonts = {})
       instructions = [instructions] unless instructions.kind_of?(Array)
       instructions = instructions.map { |ins|
         ins.is_a?(PDF::Reader::Stream) ? ins.unfiltered_data : ins.to_s

--- a/lib/pdf/reader/pages_strategy.rb
+++ b/lib/pdf/reader/pages_strategy.rb
@@ -399,7 +399,7 @@ class PDF::Reader
           params << token
         end
       end
-    rescue EOFError => e
+    rescue EOFError
       raise MalformedPDFError, "End Of File while processing a content stream"
     end
     ################################################################################

--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -60,7 +60,7 @@ class PDF::Reader
     #
     # buffer - a PDF::Reader::Buffer object that contains PDF data
     # objects  - a PDF::Reader::ObjectHash object that can return objects from the PDF file
-    def initialize (buffer, objects=nil)
+    def initialize(buffer, objects=nil)
       @buffer = buffer
       @objects  = objects
     end
@@ -69,7 +69,7 @@ class PDF::Reader
     # object
     #
     # operators - a hash of supported operators to read from the underlying buffer.
-    def parse_token (operators={})
+    def parse_token(operators={})
       token = @buffer.token
 
       if STRATEGIES.has_key? token
@@ -93,7 +93,7 @@ class PDF::Reader
     #
     # id  - the object ID to return
     # gen - the object revision number to return
-    def object (id, gen)
+    def object(id, gen)
       Error.assert_equal(parse_token, id)
       Error.assert_equal(parse_token, gen)
       Error.str_assert(parse_token, "obj")
@@ -198,7 +198,7 @@ class PDF::Reader
 
     ################################################################################
     # Decodes the contents of a PDF Stream and returns it as a Ruby String.
-    def stream (dict)
+    def stream(dict)
       raise MalformedPDFError, "PDF malformed, missing stream length" unless dict.has_key?(:Length)
       if @objects
         length = @objects.deref(dict[:Length])

--- a/lib/pdf/reader/reference.rb
+++ b/lib/pdf/reader/reference.rb
@@ -32,7 +32,7 @@ class PDF::Reader
     attr_reader :id, :gen
     ################################################################################
     # Create a new Reference to an object with the specified id and revision number
-    def initialize (id, gen)
+    def initialize(id, gen)
       @id, @gen = id, gen
     end
     ################################################################################

--- a/lib/pdf/reader/register_receiver.rb
+++ b/lib/pdf/reader/register_receiver.rb
@@ -64,7 +64,6 @@ class PDF::Reader
 
       indexes = (0..(callbacks.size-1))
       method_indexes = (0..(methods.size-1))
-      match = nil
 
       indexes.each do |idx|
         count = methods.size

--- a/lib/pdf/reader/stream.rb
+++ b/lib/pdf/reader/stream.rb
@@ -37,7 +37,7 @@ class PDF::Reader
     ################################################################################
     # Creates a new stream with the specified dictionary and data. The dictionary
     # should be a standard ruby hash, the data should be a standard ruby string.
-    def initialize (hash, data)
+    def initialize(hash, data)
       @hash = hash
       @data = data
       @udata = nil

--- a/lib/pdf/reader/text_receiver.rb
+++ b/lib/pdf/reader/text_receiver.rb
@@ -198,7 +198,7 @@ class PDF::Reader
 
       params.each do |p|
         case p
-        when Float, Fixnum
+        when Float, Integer
           @state.last[:tj_adjustment] = p
         else
           show_text(p)

--- a/lib/pdf/reader/text_receiver.rb
+++ b/lib/pdf/reader/text_receiver.rb
@@ -39,13 +39,13 @@ class PDF::Reader
   class TextReceiver
     ################################################################################
     # Initialize with the library user's receiver
-    def initialize (main_receiver)
+    def initialize(main_receiver)
       @main_receiver = main_receiver
       @upper_corners = []
     end
     ################################################################################
     # Called when the document parsing begins
-    def begin_document (root)
+    def begin_document(root)
       @upper_corners = []
     end
     ################################################################################
@@ -54,7 +54,7 @@ class PDF::Reader
       @state.clear
     end
     ################################################################################
-    def begin_page_container (page)
+    def begin_page_container(page)
       @upper_corners.push(media_box_check(page))
     end
     ################################################################################
@@ -63,7 +63,7 @@ class PDF::Reader
     end
     ################################################################################
     # Called when new page parsing begins
-    def begin_page (info)
+    def begin_page(info)
       @page = info
 
       @state = [{
@@ -101,29 +101,29 @@ class PDF::Reader
     end
     ################################################################################
     # PDF operator Tm
-    def set_text_matrix_and_text_line_matrix (*args)
+    def set_text_matrix_and_text_line_matrix(*args)
       # these variable names look bad, but they're from the PDF spec
       a, b, c, d, e, f = *args
       calculate_line_and_location(f)
     end
     ################################################################################
     # PDF operator Tc
-    def set_character_spacing (n)
+    def set_character_spacing(n)
       @state.last[:char_spacing] = n
     end
     ################################################################################
     # PDF operator Tw
-    def set_word_spacing (n)
+    def set_word_spacing(n)
       @state.last[:word_spacing] = n
     end
     ################################################################################
     # PDF operator Tz
-    def set_horizontal_text_scaling (n)
+    def set_horizontal_text_scaling(n)
       @state.last[:hori_scaling] = n/100
     end
     ################################################################################
     # PDF operator TL
-    def set_text_leading (n)
+    def set_text_leading(n)
       @state.last[:leading] = n
     end
     ################################################################################
@@ -133,19 +133,19 @@ class PDF::Reader
     end
     ################################################################################
     # PDF operator Td
-    def move_text_position (tx, ty)
+    def move_text_position(tx, ty)
       #puts "#{tx} #{ty} Td"
       calculate_line_and_location(@location + ty)
     end
     ################################################################################
     # PDF operator TD
-    def move_text_position_and_set_leading (tx, ty)
+    def move_text_position_and_set_leading(tx, ty)
       set_text_leading(ty)# * -1)
       move_text_position(tx, ty)
     end
     ################################################################################
     # PDF operator Tj
-    def show_text (string)
+    def show_text(string)
       #puts "getting line #@line"
 
       place = (@output[@line] ||= "")
@@ -157,7 +157,7 @@ class PDF::Reader
       #puts "place is now: #{place}"
       @written_to = true
     end
-    def super_show_text (string)
+    def super_show_text(string)
       urx = @upper_corners.last[:urx]/TS_UNITS_PER_H_CHAR
       ury = @upper_corners.last[:ury]/TS_UNITS_PER_V_CHAR
 
@@ -193,7 +193,7 @@ class PDF::Reader
     end
     ################################################################################
     # PDF operator TJ
-    def show_text_with_positioning (params)
+    def show_text_with_positioning(params)
       prev_adjustment = @state.last[:tj_adjustment]
 
       params.each do |p|
@@ -209,19 +209,19 @@ class PDF::Reader
     end
     ################################################################################
     # PDF operator '
-    def move_to_next_line_and_show_text (string)
+    def move_to_next_line_and_show_text(string)
       move_to_start_of_next_line
       show_text(string)
     end
     ################################################################################
     # PDF operator "
-    def set_spacing_next_line_show_text (aw, ac, string)
+    def set_spacing_next_line_show_text(aw, ac, string)
       set_word_spacing(aw)
       set_character_spacing(ac)
       move_to_next_line_and_show_text(string)
     end
     ################################################################################
-    def media_box_check (dict)
+    def media_box_check(dict)
       corners = (@upper_corners.last || {:urx => 0, :ury => 0}).dup
 
       if dict.has_key?(:MediaBox)
@@ -233,7 +233,7 @@ class PDF::Reader
       corners
     end
     ################################################################################
-    def calculate_line_and_location (new_loc)
+    def calculate_line_and_location(new_loc)
       ##puts "calculate_line_and_location(#{new_loc})"
       key = new_loc; key.freeze
 

--- a/lib/pdf/reader/text_receiver.rb
+++ b/lib/pdf/reader/text_receiver.rb
@@ -103,7 +103,7 @@ class PDF::Reader
     # PDF operator Tm
     def set_text_matrix_and_text_line_matrix(*args)
       # these variable names look bad, but they're from the PDF spec
-      a, b, c, d, e, f = *args
+      _a, _b, _c, _d, _e, f = *args
       calculate_line_and_location(f)
     end
     ################################################################################

--- a/lib/pdf/reader/token.rb
+++ b/lib/pdf/reader/token.rb
@@ -33,7 +33,7 @@ class PDF::Reader
   class Token < String # :nodoc:
     ################################################################################
     # Creates a new token with the specified value
-    def initialize (val)
+    def initialize(val)
       super
     end
     ################################################################################

--- a/lib/pdf/reader/xref.rb
+++ b/lib/pdf/reader/xref.rb
@@ -53,7 +53,7 @@ class PDF::Reader
     #
     # io - must be an IO object, generally either a file or a StringIO
     #
-    def initialize (io)
+    def initialize(io)
       @io = io
       @junk_offset = calc_junk_offset(io) || 0
       @xref = {}
@@ -219,7 +219,7 @@ class PDF::Reader
     ################################################################################
     # Stores an offset value for a particular PDF object ID and revision number
     #
-    def store (id, gen, offset)
+    def store(id, gen, offset)
       (@xref[id] ||= {})[gen] ||= offset
     end
     ################################################################################

--- a/spec/callback_spec.rb
+++ b/spec/callback_spec.rb
@@ -58,11 +58,11 @@ describe PDF::Reader do
 
   describe  "page_count callback" do
     CallbackHelper.instance.good_receivers.each do |filename, receiver|
-      it "should return a single Fixnum argument that is > 0 on #{filename}" do
+      it "should return a single Integer argument that is > 0 on #{filename}" do
 
         receiver.all_args(:page_count).each do |args|
           expect(args.size).to eq 1
-          expect(args[0]).to be_a(Fixnum)
+          expect(args[0]).to be_a(Integer)
           expect(args[0] > 0).to be true
         end
 
@@ -239,7 +239,7 @@ describe PDF::Reader do
       it "should return an array of Numbers and UTF-8 strings on #{filename}" do
         receiver.all_args(:show_text_with_positioning).each do |args|
           args[0].each do |arg|
-            expect(arg.class == String || arg.class == Fixnum || arg.class == Float).to eq true
+            expect(String === arg || Integer === arg || Float === arg).to eq true
           end
           check_utf8(args)
         end

--- a/spec/object_hash_spec.rb
+++ b/spec/object_hash_spec.rb
@@ -21,7 +21,7 @@ describe PDF::Reader::ObjectHash do
   end
 
   it "should raise an ArgumentError if passed a non filename and non IO" do
-    filename = pdf_spec_file("cairo-unicode")
+    pdf_spec_file("cairo-unicode")
      expect {PDF::Reader::ObjectHash.new(10)}.to raise_error(ArgumentError)
   end
 
@@ -342,9 +342,6 @@ describe PDF::Reader::ObjectHash, "trailer method" do
     filename = pdf_spec_file("cairo-unicode")
     h = PDF::Reader::ObjectHash.new(filename)
 
-    expected = {:Size => 58,
-                :Root => PDF::Reader::Reference.new(57,0),
-                :Info => PDF::Reader::Reference.new(56,0)}
     expect(h.trailer[:Size]).to eql(58)
     expect(h.trailer[:Root]).to eql(PDF::Reader::Reference.new(57,0))
     expect(h.trailer[:Info]).to eql(PDF::Reader::Reference.new(56,0))

--- a/spec/support/buffer_helper.rb
+++ b/spec/support/buffer_helper.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 module BufferHelper
-  def parse_string (r)
+  def parse_string(r)
     PDF::Reader::Buffer.new(StringIO.new(r))
   end
 end

--- a/spec/support/core_ext.rb
+++ b/spec/support/core_ext.rb
@@ -3,5 +3,5 @@
 class Array
   def to_h
     Hash[*self.flatten]
-  end
+  end unless defined? :to_h
 end

--- a/spec/support/parser_helper.rb
+++ b/spec/support/parser_helper.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 module ParserHelper
-  def parse_string (r)
+  def parse_string(r)
     buf = PDF::Reader::Buffer.new(StringIO.new(r))
     PDF::Reader::Parser.new(buf, nil)
   end


### PR DESCRIPTION
Here are fixes for some Ruby 2.4 related warnings plus some more trivial warnings.

Note that the Fixnum fix includes a little bit of incompatibility where `value == Fixnum` became `Integer === value`. The behavior might change if the value was a very huge number (Bignum) or `value.class` was overwritten.