### PR TITLE
Avoid stack overflow

### DIFF
--- a/spec/data/form_xobject_recursive.pdf
+++ b/spec/data/form_xobject_recursive.pdf
@@ -1,0 +1,103 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 15
+>>
+stream
+q
+/Stamp1 Do
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612.0 792.0]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/XObject << /Stamp1 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /XObject
+/Subtype /Form
+/BBox [0 0 612.0 792.0]
+/XObject << /RecursiveForm 6 0 R
+>>
+/Resources << /Font << /F1.0 7 0 R
+>>
+>>
+/Length 476
+>>
+stream
+q
+/DeviceRGB cs
+0.000 0.000 0.000 scn
+/DeviceRGB CS
+0.000 0.000 0.000 SCN
+1 w
+0 J
+0 j
+[] 0 d
+51.0 51.0 m
+51.0 53.7614 48.7614 56.0 46.0 56.0 c
+43.2386 56.0 41.0 53.7614 41.0 51.0 c
+41.0 48.2386 43.2386 46.0 46.0 46.0 c
+48.7614 46.0 51.0 48.2386 51.0 51.0 c
+46.0 51.0 m
+f
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<746869732066> 30 <6f72> -25 <6d20584f626a65637420636f6e7461696e73206120726566> 30 <6572656e636520746f20697473656c6620696e20697473205265736f75726365732064696374>] TJ
+ET
+
+Q
+
+endstream
+endobj
+7 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000280 00000 n 
+0000000463 00000 n 
+0000001121 00000 n 
+trailer
+<< /Size 8
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+1218
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -214,6 +214,16 @@ describe PDF::Reader, "integration specs" do
     end
   end
 
+  context "PDF that has a Form XObjects that references itself" do
+    let(:filename) { pdf_spec_file("form_xobject_recursive") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        expect(reader.page(1).text).to include("this form XObject contains a reference to itself")
+      end
+    end
+  end
+
   context "PDF that uses multiple content streams for a single page" do
     let(:filename) { pdf_spec_file("split_params_and_operator") }
 

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -134,6 +134,9 @@ data/form_xobject.pdf:
 data/form_xobject_more.pdf:
   :bytes: 22055
   :md5: 1fcbd5a3f7429dd224871d8d9d7830a7
+data/form_xobject_recursive.pdf:
+  :bytes: 1454
+  :md5: 24cbbe4f91c23b37f9a1ddac81bd3a39
 data/hard_lock_under_osx.pdf:
   :bytes: 4545
   :md5: 365e2076036b5e2445d1dcde13d6dbb6

--- a/spec/object_hash_spec.rb
+++ b/spec/object_hash_spec.rb
@@ -126,6 +126,22 @@ describe PDF::Reader::ObjectHash do
       expect(orig_collection.object_id).not_to eq(new_collection.object_id)
     end
 
+    # a -> b -> c -> a
+    context "with nested Array's that reference themselves" do
+      let(:a) { [1, b] }
+      let(:b) { [2, c] }
+      let(:c) { [3] }
+
+      before do
+        c << a
+      end
+
+      it "returns a new Array, not mutate the provided Array" do
+        result = hash.deref!(c)
+
+        expect(result).to be_a(Array)
+      end
+    end
   end
 
   describe "#fetch" do


### PR DESCRIPTION
This is an alternative solution to #195. This version is messier and less elegant, but more correct. Assuming it builds green, I'm inclined to merge this one instead and refactor later with the safety of the new specs.

`deref!` was added in 9c520b6 and attempts to return a deep object graph that contains no `PDF::Reader::Reference` objects and can be walked without risk of needing to refer back to the associated `ObjectHash` instance.

This change resolves a recursion bug that can occur in real world files