### PR TITLE
recognise glyph names that map automatically to glyph codes

### DIFF
--- a/lib/pdf/reader/glyph_hash.rb
+++ b/lib/pdf/reader/glyph_hash.rb
@@ -48,6 +48,9 @@ class PDF::Reader
     #   h.name_to_unicode(:Euro)
     #   => 8364
     #
+    #   h.name_to_unicode(:X4A)
+    #   => 74
+    #
     #   h.name_to_unicode(:G30)
     #   => 48
     #
@@ -62,6 +65,8 @@ class PDF::Reader
 
       if @by_name.has_key?(name)
         @by_name[name]
+      elsif str.match(/\AX[0-9a-fA-F]{2,4}\Z/)
+        "0x#{str[1,4]}".hex
       elsif str.match(/\Auni[A-F\d]{4}\Z/)
         "0x#{str[3,4]}".hex
       elsif str.match(/\Au[A-F\d]{4,6}\Z/)

--- a/spec/glyph_hash_spec.rb
+++ b/spec/glyph_hash_spec.rb
@@ -31,6 +31,14 @@ describe PDF::Reader::GlyphHash do
       expect(map.name_to_unicode(:u123456)).to eql(0x123456)
     end
 
+    it "correctly maps a Xnn glyph to unicode" do
+      map = PDF::Reader::GlyphHash.new
+      expect(map.name_to_unicode(:X20)).to     eql(32)
+      expect(map.name_to_unicode(:X4A)).to     eql(74)
+      expect(map.name_to_unicode(:X4A4)).to    eql(1188)
+      expect(map.name_to_unicode(:X4a4a)).to   eql(19018)
+    end
+
     it "correctly maps a Ann glyph to unicode" do
       map = PDF::Reader::GlyphHash.new
       expect(map.name_to_unicode(:A65)).to     eql(65)


### PR DESCRIPTION
PDFs in the wild appear to sometimes use a glyph name like X4A and expect it to be automatically converted to to glyph code 74.

Hex 4A -> Decimal 74