### PR TITLE
Support PDFs that use direct objects in a Kids array

### DIFF
--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -339,7 +339,7 @@ class PDF::Reader
     # returns a nested array of object references for all pages in this object store.
     #
     def get_page_objects(ref)
-      obj = fetch(ref)
+      obj = deref(ref)
 
       if obj[:Type] == :Page
         ref

--- a/spec/data/kids-as-direct-objects.pdf
+++ b/spec/data/kids-as-direct-objects.pdf
@@ -1,0 +1,90 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 2
+/Kids [<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612.0 792.0]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 5 0 R
+>>
+>>
+>> << /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612.0 792.0]
+/Contents 6 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 5 0 R
+>>
+>>
+>>]
+>>
+endobj
+4 0 obj
+<< /Length 60
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<706167652031>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+6 0 obj
+<< /Length 60
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<706167652032>] TJ
+ET
+
+Q
+
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000535 00000 n 
+0000000645 00000 n 
+0000000742 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+852
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -841,4 +841,15 @@ describe PDF::Reader, "integration specs" do
     end
   end
 
+  context "PDF where the entries in a Kids array are direct objects, rather than indirect" do
+    let(:filename) { pdf_spec_file("kids-as-direct-objects") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to eq("page 1")
+      end
+    end
+  end
+
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -182,6 +182,9 @@ data/invalid/trailer_is_not_a_dict.pdf:
 data/junk_prefix.pdf:
   :bytes: 934
   :md5: c03c9a96cdefa78c9475b619d87e39bf
+data/kids-as-direct-objects.pdf:
+  :bytes: 1067
+  :md5: 90d7e0ac0b0f886ae062b9efa8f3afb6
 data/large_single_line_content_stream.pdf:
   :bytes: 229020
   :md5: 70f89c25291e4f01fff335188d7c1910


### PR DESCRIPTION
Normally the Kids array in a Pages object contains only indirect objects. It seems a few PDF producing apps violate that rule and make Kids an Array of direct Page(s) objects.

This is against spec, but Acrobat supports it and it's trivial to fix.

Thanks to @bhayani in #159 for reporting the issue