### PR TITLE
add AESv2 encryption (PDF 1.6 spec) support

### DIFF
--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -300,7 +300,8 @@ class PDF::Reader
           permissions: encrypt[:P].to_i,
           encrypted_metadata: encmeta,
           file_id: (deref(trailer[:ID]) || []).first,
-          password: opts[:password]
+          password: opts[:password],
+          cfm: encrypt.fetch(:CF, {}).fetch(encrypt[:StmF], {}).fetch(:CFM, nil)
         )
       else
         UnimplementedSecurityHandler.new

--- a/lib/pdf/reader/standard_security_handler.rb
+++ b/lib/pdf/reader/standard_security_handler.rb
@@ -80,31 +80,47 @@ class PDF::Reader
     #
     # Algorithm 1: Encryption of data using the RC4 or AES algorithms
     #
-    # used to decrypt RC4 encrypted PDF streams (buf)
+    # used to decrypt RC4/AES encrypted PDF streams (buf)
     #
     # buf - a string to decrypt
     # ref - a PDF::Reader::Reference for the object to decrypt
     #
     def decrypt( buf, ref )
-      objKey = @encrypt_key.dup
-      (0..2).each { |e| objKey << (ref.id >> e*8 & 0xFF ) }
-      (0..1).each { |e| objKey << (ref.gen >> e*8 & 0xFF ) }
-      if @cfm == :AESV2
-        objKey << 'sAlT'  # Algorithm 1, b)
-        length = objKey.length < 16 ? objKey.length : 16
-        cipher = OpenSSL::Cipher.new("AES-#{length << 3}-CBC")
-        cipher.decrypt
-        cipher.key = Digest::MD5.digest(objKey)[0,length]
-        cipher.iv = buf[0..15]
-        cipher.update(buf[16..-1]) + cipher.final
-      else
-        length = objKey.length < 16 ? objKey.length : 16
-        rc4 = RC4.new( Digest::MD5.digest(objKey)[0,length] )
-        rc4.decrypt(buf)
+      case @cfm
+        when :AESV2
+          decrypt_aes128(buf, ref)
+        else
+          decrypt_rc4(buf, ref)
       end
     end
 
     private
+
+    # decrypt with RC4 algorithm
+    # version <=3 or (version == 4 and CFM == V2)
+    def decrypt_rc4( buf, ref )
+      objKey = @encrypt_key.dup
+      (0..2).each { |e| objKey << (ref.id >> e*8 & 0xFF ) }
+      (0..1).each { |e| objKey << (ref.gen >> e*8 & 0xFF ) }
+      length = objKey.length < 16 ? objKey.length : 16
+      rc4 = RC4.new( Digest::MD5.digest(objKey)[0,length] )
+      rc4.decrypt(buf)
+    end
+
+    # decrypt with AES-128-CBC algorithm
+    # when (version == 4 and CFM == AESV2)
+    def decrypt_aes128( buf, ref )
+      objKey = @encrypt_key.dup
+      (0..2).each { |e| objKey << (ref.id >> e*8 & 0xFF ) }
+      (0..1).each { |e| objKey << (ref.gen >> e*8 & 0xFF ) }
+      objKey << 'sAlT'  # Algorithm 1, b)
+      length = objKey.length < 16 ? objKey.length : 16
+      cipher = OpenSSL::Cipher.new("AES-#{length << 3}-CBC")
+      cipher.decrypt
+      cipher.key = Digest::MD5.digest(objKey)[0,length]
+      cipher.iv = buf[0..15]
+      cipher.update(buf[16..-1]) + cipher.final
+    end
 
     # Pads supplied password to 32bytes using PassPadBytes as specified on
     # pp61 of spec

--- a/lib/pdf/reader/standard_security_handler.rb
+++ b/lib/pdf/reader/standard_security_handler.rb
@@ -25,6 +25,7 @@
 #
 ################################################################################
 require 'digest/md5'
+require 'openssl'
 require 'rc4'
 
 class PDF::Reader
@@ -54,6 +55,7 @@ class PDF::Reader
       @encryptMeta   = opts.fetch(:encrypted_metadata, true)
       @file_id       = opts[:file_id] || ""
       @encrypt_key   = build_standard_key(opts[:password] || "")
+      @cfm           = opts[:cfm]
 
       if @key_length != 5 && @key_length != 16
         msg = "StandardSecurityHandler only supports 40 and 128 bit\
@@ -70,8 +72,8 @@ class PDF::Reader
       filter = encrypt.fetch(:Filter, :Standard)
       version = encrypt.fetch(:V, 0)
       algorithm = encrypt.fetch(:CF, {}).fetch(encrypt[:StmF], {}).fetch(:CFM, nil)
-      filter == :Standard &&
-        (version <= 3 || (version == 4 && algorithm != :AESV2))
+      (filter == :Standard) && (encrypt[:StmF] == encrypt[:StrF]) &&
+        (version <= 3 || (version == 4 && ((algorithm == :V2) || (algorithm == :AESV2))))
     end
 
     ##7.6.2 General Encryption Algorithm
@@ -87,9 +89,19 @@ class PDF::Reader
       objKey = @encrypt_key.dup
       (0..2).each { |e| objKey << (ref.id >> e*8 & 0xFF ) }
       (0..1).each { |e| objKey << (ref.gen >> e*8 & 0xFF ) }
-      length = objKey.length < 16 ? objKey.length : 16
-      rc4 = RC4.new( Digest::MD5.digest(objKey)[0,length] )
-      rc4.decrypt(buf)
+      if @cfm == :AESV2
+        objKey << 'sAlT'  # Algorithm 1, b)
+        length = objKey.length < 16 ? objKey.length : 16
+        cipher = OpenSSL::Cipher.new("AES-#{length << 3}-CBC")
+        cipher.decrypt
+        cipher.key = Digest::MD5.digest(objKey)[0,length]
+        cipher.iv = buf[0..15]
+        cipher.update(buf[16..-1]) + cipher.final
+      else
+        length = objKey.length < 16 ? objKey.length : 16
+        rc4 = RC4.new( Digest::MD5.digest(objKey)[0,length] )
+        rc4.decrypt(buf)
+      end
     end
 
     private

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -518,22 +518,44 @@ describe PDF::Reader, "integration specs" do
     context "with the user pass" do
       let(:pass) { "apples" }
 
-      # TODO: remove this spec
-      it "raises UnsupportedFeatureError" do
-        expect {
-          PDF::Reader.open(filename, :password => pass) do |reader|
-            reader.page(1).text
-          end
-        }.to raise_error(PDF::Reader::EncryptedPDFError)
+      it "correctly extracts text" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.page(1).text).to include("This sample file is encrypted")
+        end
       end
 
-      it "correctly extracts text"
-      it "correctly extracts info"
+      it "correctly extracts info" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.info).to eq(
+            :CreationDate=>"D:20110814231057+10'00'",
+            :Creator=>"Writer",
+            :ModDate=>"D:20170115224117+11'00'",
+            :Producer=>"LibreOffice 3.3",
+          )
+        end
+      end
     end
 
     context "with the owner pass" do
-      it "correctly extracts text"
-      it "correctly extracts info"
+      let(:pass) { "password" }
+
+      it "correctly extracts text" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.page(1).text).to include("This sample file is encrypted")
+        end
+      end
+
+      it "correctly extracts info" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.info).to eq(
+            :CreationDate=>"D:20110814231057+10'00'",
+            :Creator=>"Writer",
+            :ModDate=>"D:20170115224117+11'00'",
+            :Producer=>"LibreOffice 3.3",
+          )
+        end
+      end
+
     end
   end
 
@@ -545,22 +567,45 @@ describe PDF::Reader, "integration specs" do
     context "with the user pass" do
       let(:pass) { "apples" }
 
-      # TODO: remove this spec
-      it "raises UnsupportedFeatureError" do
-        expect {
-          PDF::Reader.open(filename, :password => pass) do |reader|
-            reader.page(1).text
-          end
-        }.to raise_error(PDF::Reader::EncryptedPDFError)
+      it "correctly extracts text" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.page(1).text).to include("This sample file is encrypted")
+        end
       end
 
-      it "correctly extracts text"
-      it "correctly extracts info"
+      it "correctly extracts info" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.info).to eq(
+            :CreationDate=>"D:20110814231057+10'00'",
+            :Creator=>"Writer",
+            :ModDate=>"D:20170115224244+11'00'",
+            :Producer=>"LibreOffice 3.3",
+          )
+        end
+      end
+
     end
 
     context "with the owner pass" do
-      it "correctly extracts text"
-      it "correctly extracts info"
+      let(:pass) { "password" }
+
+      it "correctly extracts text" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.page(1).text).to include("This sample file is encrypted")
+        end
+      end
+
+      it "correctly extracts info" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.info).to eq(
+            :CreationDate=>"D:20110814231057+10'00'",
+            :Creator=>"Writer",
+            :ModDate=>"D:20170115224244+11'00'",
+            :Producer=>"LibreOffice 3.3",
+          )
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
 - add extra check (`encrypt[:StmF] == encrypt[:StrF]`)
 - pass `encrypt[:CFM]` to `StandardSecurityHandler` constructor
 - implement test cases for AES128 encrypted files