### PR TITLE
Private methods cleanup

### DIFF
--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -198,10 +198,6 @@ class PDF::Reader
       end
     end
 
-    def has_mapping?
-      @mapping.size > 0
-    end
-
     def glyphlist
       @glyphlist ||= PDF::Reader::GlyphHash.new
     end

--- a/lib/pdf/reader/lzw.rb
+++ b/lib/pdf/reader/lzw.rb
@@ -116,11 +116,10 @@ module PDF
         result
       end
 
-      private
-
       def self.create_new_string(string_table,some_code, other_code)
         string_table[some_code] + string_table[other_code][0].chr
       end
+      private_class_method :create_new_string
 
     end
   end


### PR DESCRIPTION
This is just a minor code cleanup:
- removing an old and unused function `has_mapping?`
- using `private_class_method` for `PDF::Reader::LZW.create_new_string`, since the `private` keyword does not have any effect for class methods.