### PR TITLE
Fix occasional invalid UTF-8 byte sequences

### DIFF
--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -101,6 +101,9 @@ module PDF
           # paint the current glyph
           newx, newy = @state.trm_transform(0,0)
           utf8_chars = @state.current_font.to_utf8(glyph_code)
+          if !utf8_chars.valid_encoding?
+            utf8_chars = utf8_chars.encode("UTF-8", invalid: :replace, undef: :replace)
+          end
 
           # apply to glyph displacment for the current glyph so the next
           # glyph will appear in the correct position


### PR DESCRIPTION
A big PDF file we were parsing had some UTF-8 glyphs that caused the code to crash in the following code example:

```ruby
reader = PDF::Reader.new(file_path)
reader.pages.each do |reader_page|
        puts reader_page.text
end
```

After rootling through the gem it seems that occasionally the to_utf8 function still gives invalid encodings. This pull request just does a belt-and-braces check to the utf8_chars before continuing.