### PR TITLE
Dereference page attribute values

### DIFF
--- a/lib/pdf/reader/page.rb
+++ b/lib/pdf/reader/page.rb
@@ -58,7 +58,11 @@ module PDF
       def attributes
         @attributes ||= {}.tap { |hash|
           page_with_ancestors.reverse.each do |obj|
-            hash.merge!(@objects.deref(obj))
+            deref_obj = @objects.deref(obj)
+            deref_obj.each do |key, value|
+              deref_obj[key] = @objects.deref(value)
+            end
+            hash.merge!(deref_obj)
           end
         }
         # This shouldn't be necesary, but some non compliant PDFs leave MediaBox

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -11,6 +11,9 @@ data/adobe_sample.pdf:
 data/ascii85_filter.pdf:
   :bytes: 21288
   :md5: 49502f60a3f058e20d0564312c9dda2b
+data/attribute_values_as_references.pdf:
+  :bytes: 5048232
+  :md5: 5a03bdef5a203f4763aee252d4cbb507
 data/broken_string.pdf:
   :bytes: 929
   :md5: f717634f2e419e496e1e93a0cb5b7d18
@@ -169,7 +172,7 @@ data/inline_image.pdf:
   :md5: b02bfbb6b0ee7c7d7df1b5f0c1f198c1
 data/inline_image_single_line_content_stream.pdf:
   :bytes: 130786
-  :md5: 096fb28baf29a716066768cb31182b73
+  :md5: '096fb28baf29a716066768cb31182b73'
 data/invalid/data.csv:
   :bytes: 26
   :md5: 7168179491824d651a304cbb83c16964
@@ -301,7 +304,7 @@ data/type3_font.pdf:
   :md5: ef2a3eb57d5996c4a33681e1aec98f2c
 data/type3_font_with_rare_font_matrix.pdf:
   :bytes: 11541
-  :md5: 08f69084d72dabc5dfdcf5c1ff2a719f
+  :md5: '08f69084d72dabc5dfdcf5c1ff2a719f'
 data/vertical-text-in-identity-v.pdf:
   :bytes: 9785
   :md5: 8dba658e634fb19a66090607640540d1

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -144,6 +144,14 @@ describe PDF::Reader::Page do
       attribs = @page.attributes
       expect(attribs[:MediaBox]).to eql([0,0,612,792])
     end
+
+    it 'dereferences values' do
+      @browser = PDF::Reader.new(pdf_spec_file("attribute_values_as_references"))
+      @page    = @browser.page(1)
+
+      attribs = @page.attributes
+      expect(attribs[:MediaBox]).to eq([0,0,750,1170])
+    end
   end
 
 


### PR DESCRIPTION
For the included PDF file, the MediaBox attribute references a Reference instead of the array of numbers. Dereferencing it returns the array of numbers.

Should fix #253.

The included PDF demonstrating the issue for the test suite is 5MB, but I'm not sure how to reduce the PDF to demonstrate the issue and nothing else.