### PR TITLE
Confirm that we can extract text from docs with an indirect MediaBox

### DIFF
--- a/spec/data/indirect_mediabox.pdf
+++ b/spec/data/indirect_mediabox.pdf
@@ -1,0 +1,77 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [6 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 184
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<546865204d65646961426f> 30 <782066> 30 <6f7220746869732070616765206973207370656369666965642076696120616e20696e646972656374206f626a656374>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+[0 0 612.0 792.0]
+endobj
+6 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox 5 0 R
+/CropBox [0 0 612.0 792.0]
+/BleedBox [0 0 612.0 792.0]
+/TrimBox [0 0 612.0 792.0]
+/ArtBox [0 0 612.0 792.0]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 7 0 R
+>>
+>>
+>>
+endobj
+7 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000450 00000 n 
+0000000483 00000 n 
+0000000757 00000 n 
+trailer
+<< /Size 8
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+854
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1033,4 +1033,15 @@ describe PDF::Reader, "integration specs" do
       end
     end
   end
+
+  context "PDF with MediaBox specified as an indirect object" do
+    let(:filename) { pdf_spec_file("indirect_mediabox") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to eq("The MediaBox for this page is specified via an indirect object")
+      end
+    end
+  end
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -152,6 +152,9 @@ data/hard_lock_under_osx.pdf:
 data/indirect_kids_array.pdf:
   :bytes: 951
   :md5: 7cb585bfe3f5266ed50bd205422953fd
+data/indirect_mediabox.pdf:
+  :bytes: 1089
+  :md5: 49a6957e4ecb6da14f4ab546909389d5
 data/indirect_page_count.pdf:
   :bytes: 957
   :md5: a84031df45b2431aabd2ca3107321c08


### PR DESCRIPTION
This test file was generated as part of the discussion in #263 and although the decision was not to merge that PR, we may as well add the file to our regression tests.