### PR TITLE
manually specify that we want to build in the travis LTS environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+group: travis_lts
 rvm:
   - 1.9.3
   - 2.0


### PR DESCRIPTION
This is currently Ubuntu 14.04 (Trusty), but may change in the future (hopefully slowly).