### PR TITLE
Improve performance of PDF::Reader::Filter::Depredict#png_depredict

### DIFF
--- a/lib/pdf/reader/filter/depredict.rb
+++ b/lib/pdf/reader/filter/depredict.rb
@@ -67,8 +67,7 @@ class PDF::Reader
         row = 0
         pixels = []
         paeth, pa, pb, pc = nil
-        until data.empty? do
-          row_data = data.slice! 0, scanline_length
+        data.each_slice(scanline_length) do |row_data|
           filter = row_data.shift
           case filter
           when 0 # None


### PR DESCRIPTION
Calling Array#slice! for each row could impact performance. When pdf files have cross reference stream with predictor functions, it takes really long time to open them.