### PR TITLE
Supports: xref streams with 64bit

### DIFF
--- a/lib/pdf/reader/xref.rb
+++ b/lib/pdf/reader/xref.rb
@@ -204,6 +204,8 @@ class PDF::Reader
         ("\x00" + bytes).unpack("N")[0]
       elsif bytes.size == 4
         bytes.unpack("N")[0]
+      elsif bytes.size == 8
+        bytes.unpack("Q>")[0]
       else
         raise UnsupportedFeatureError, "Unable to unpack xref stream entries with more than 4 bytes"
       end


### PR DESCRIPTION
Fixes UnsupportedFeatureError for 64 bit xref streams (Message PDF::Reader::UnsupportedFeatureError - Unable to unpack xref stream entries with more than 4 bytes)

After some trying, the order seems to be Big Endian 64bit ("Q>").

Unfortunately, I am not be able to share the document that caused this error for privacy reasons. I also don't find any documentation on xrefs, as I am not familiar with PDF file format.

I can understand, if you would not like to merge a commit without any attached test, but maybe this is useful for other people with the same error.
