### PR TITLE
Fix: TrueType.glyph_width returning nil

### DIFF
--- a/lib/pdf/reader/width_calculator/true_type.rb
+++ b/lib/pdf/reader/width_calculator/true_type.rb
@@ -17,8 +17,7 @@ class PDF::Reader
 
       def glyph_width(code_point)
         return 0 if code_point.nil? || code_point < 0
-
-        glyph_width_from_font(code_point) || glyph_width_from_descriptor(code_point)
+        glyph_width_from_font(code_point) || glyph_width_from_descriptor(code_point) || 0
       end
 
       private


### PR DESCRIPTION
ensure that WidthCalculator::TrueType.glyph_width always return a numeric value
