### PR TITLE
Detect orientation for all rotations

### DIFF
--- a/lib/pdf/reader/orientation_detector.rb
+++ b/lib/pdf/reader/orientation_detector.rb
@@ -25,9 +25,9 @@ class PDF::Reader
       width           = urx.to_i - llx.to_i
       height          = ury.to_i - lly.to_i
       if width > height
-        [0,180].include?(rotation) ? 'landscape' : 'portrait'
+        (rotation % 180).zero? ? 'landscape' : 'portrait'
       else
-        [0,180].include?(rotation) ? 'portrait' : 'landscape'
+        (rotation % 180).zero? ? 'portrait' : 'landscape'
       end
     end
   end

--- a/spec/reader/orientation_detector_spec.rb
+++ b/spec/reader/orientation_detector_spec.rb
@@ -21,6 +21,15 @@ describe PDF::Reader::OrientationDetector do
       end
     end
 
+    context "with a portrait page and 360° rotation" do
+      let!(:detector) {
+        PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 612, 792], :Rotate => 360)
+      }
+      it "returns landscape" do
+        expect(detector.orientation).to eq('portrait')
+      end
+    end
+
     context "with a landscape page and no rotation" do
       let!(:detector) {
         PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 792, 612])
@@ -39,5 +48,13 @@ describe PDF::Reader::OrientationDetector do
       end
     end
 
+    context "with a landscape page and 360° rotation" do
+      let!(:detector) {
+        PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 792, 612], :Rotate => 360)
+      }
+      it "returns portrait" do
+        expect(detector.orientation).to eq('landscape')
+      end
+    end
   end
 end

--- a/spec/reader/orientation_detector_spec.rb
+++ b/spec/reader/orientation_detector_spec.rb
@@ -25,7 +25,7 @@ describe PDF::Reader::OrientationDetector do
       let!(:detector) {
         PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 612, 792], :Rotate => 360)
       }
-      it "returns landscape" do
+      it "returns portrait" do
         expect(detector.orientation).to eq('portrait')
       end
     end
@@ -52,7 +52,7 @@ describe PDF::Reader::OrientationDetector do
       let!(:detector) {
         PDF::Reader::OrientationDetector.new(:MediaBox => [0, 0, 792, 612], :Rotate => 360)
       }
-      it "returns portrait" do
+      it "returns landscape" do
         expect(detector.orientation).to eq('landscape')
       end
     end


### PR DESCRIPTION
If a PDF is rotated 360 or 540 degrees, for example, the orientation should still be calculated correctly