### PR TITLE
When rendering text on a page (using page#text), skip duplicate characters that overlap by 50% of more

### DIFF
--- a/lib/pdf/reader/overlapping_runs_filter.rb
+++ b/lib/pdf/reader/overlapping_runs_filter.rb
@@ -41,7 +41,7 @@ class PDF::Reader
       sweep_line_status.each do |point_in_sls|
         if event_point.x >= point_in_sls.run.x &&
             event_point.x <= point_in_sls.run.endx &&
-            point_in_sls.run.intersection_area_percent(event_point.run) > OVERLAPPING_THRESHOLD
+            point_in_sls.run.intersection_area_percent(event_point.run) >= OVERLAPPING_THRESHOLD
           return true
         end
       end

--- a/lib/pdf/reader/overlapping_runs_filter.rb
+++ b/lib/pdf/reader/overlapping_runs_filter.rb
@@ -1,0 +1,68 @@
+# coding: utf-8
+
+class PDF::Reader
+  # remove duplicates from a collection of TextRun objects. This can be helpful when a PDF
+  # uses slightly offset overlapping characters to achieve a fake 'bold' effect.
+  class OverlappingRunsFilter
+
+    # This should be between 0 and 1. If TextRun B obscures this much of TextRun A (and they
+    # have identical characters) then one will be discarded
+    OVERLAPPING_PERCENTAGE_THRESHOLD = 0.5
+
+    def self.exclude_redundant_runs(runs)
+      collection = new_marked_text_run_collection(runs)
+      collection.each do |run|
+        next unless run.keep?
+
+        collection.reject { |comp|
+          run.object_id == comp.object_id
+        }.select { |comp|
+          comp.keep? &&
+            run.text == comp.text &&
+            run.intersection_area_percent(comp) > OVERLAPPING_PERCENTAGE_THRESHOLD
+        }.each { |comp|
+          comp.discard!
+        }
+      end
+      return_umarked_items(collection)
+    end
+
+    def self.new_marked_text_run_collection(runs)
+      runs.map { |run| MarkedTextRun.new(run) }
+    end
+
+    def self.return_umarked_items(collection)
+      collection.select { |run|
+        run.keep?
+      }.map(&:run)
+    end
+
+  end
+
+  # Utility class used to avoid modifying the underlying TextRun objects while we're
+  # looking for duplicates
+  class MarkedTextRun
+    attr_reader :run
+
+    def initialize(run)
+      @run = run
+      @discard = false
+    end
+
+    def discard!
+      @discard = true
+    end
+
+    def keep?
+      !@discard
+    end
+
+    def text
+      @run.text
+    end
+
+    def intersection_area_percent(comp)
+      @run.intersection_area_percent(comp.run)
+    end
+  end
+end

--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -1,6 +1,8 @@
 # coding: utf-8
 # frozen_string_literal: true
 
+require 'pdf/reader/overlapping_runs_filter'
+
 class PDF::Reader
 
   # Takes a collection of TextRun objects and renders them into a single
@@ -15,7 +17,7 @@ class PDF::Reader
     def initialize(runs, mediabox)
       raise ArgumentError, "a mediabox must be provided" if mediabox.nil?
 
-      @runs    = merge_runs(discard_overlapping_dupes(runs))
+      @runs    = merge_runs(OverlappingRunsFilter.exclude_redundant_runs(runs))
       @mean_font_size   = mean(@runs.map(&:font_size)) || DEFAULT_FONT_SIZE
       @mean_font_size = DEFAULT_FONT_SIZE if @mean_font_size == 0
       @mean_glyph_width = mean(@runs.map(&:mean_character_width)) || 0
@@ -111,59 +113,6 @@ class PDF::Reader
         end
       end
       runs
-    end
-
-    # This won't stay here long
-    class MarkedTextRun
-      attr_reader :run
-
-      def initialize(run)
-        @run = run
-        @discard = false
-      end
-
-      def discard!
-        @discard = true
-      end
-
-      def keep?
-        !@discard
-      end
-
-      def text
-        @run.text
-      end
-
-      def intersection_area_percent(comp)
-        @run.intersection_area_percent(comp.run)
-      end
-    end
-
-    # intentionally quadratic!
-    def discard_overlapping_dupes(runs)
-      collection = new_marked_text_run_collection(runs)
-      collection.each do |run|
-        next unless run.keep?
-
-        collection.reject { |comp|
-          run.object_id == comp.object_id
-        }.select { |comp|
-          comp.keep? && run.text == comp.text && run.intersection_area_percent(comp) > 0.5
-        }.each { |comp|
-          comp.discard!
-        }
-      end
-      return_umarked_items(collection)
-    end
-
-    def new_marked_text_run_collection(runs)
-      runs.map { |run| MarkedTextRun.new(run) }
-    end
-
-    def return_umarked_items(collection)
-      collection.select { |run|
-        run.keep?
-      }.map(&:run)
     end
 
     def local_string_insert(haystack, needle, index)

--- a/lib/pdf/reader/text_run.rb
+++ b/lib/pdf/reader/text_run.rb
@@ -38,6 +38,10 @@ class PDF::Reader
       @endx ||= x + width
     end
 
+    def endy
+      @endy ||= y + font_size
+    end
+
     def mean_character_width
       @width / character_count
     end
@@ -58,6 +62,11 @@ class PDF::Reader
 
     def inspect
       "#{text} w:#{width} f:#{font_size} @#{x},#{y}"
+    end
+
+    def intersect?(other_run)
+      x <= other_run.endx && endx >= other_run.x &&
+        endy >= other_run.y && y <= other_run.endy
     end
 
     private

--- a/lib/pdf/reader/text_run.rb
+++ b/lib/pdf/reader/text_run.rb
@@ -69,7 +69,22 @@ class PDF::Reader
         endy >= other_run.y && y <= other_run.endy
     end
 
+    # return what percentage of this text run is overlapped by another run
+    def intersection_area_percent(other_run)
+      return 0 unless intersect?(other_run)
+
+      dx = [endx, other_run.endx].min - [x, other_run.x].max
+      dy = [endy, other_run.endy].min - [y, other_run.y].max
+      intersection_area = dx*dy
+
+      intersection_area.to_f / area
+    end
+
     private
+
+    def area
+      (endx - x) * (endy - y)
+    end
 
     def mergable_range
       @mergable_range ||= Range.new(endx - 3, endx + font_size)

--- a/spec/data/overlapping-chars-x-fake-bold.pdf
+++ b/spec/data/overlapping-chars-x-fake-bold.pdf
@@ -1,0 +1,80 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 512
+>>
+stream
+q
+
+BT
+85.95 636.0 Td
+/F1.0 12 Tf
+[<536f6d652063686172> 10 <6163746572732074686174206f> 15 <76> 25 <6572> -15 <6c617020776974682064696666> 30 <6572656e74205820746f206163686965> 30 <76> 25 <6520612066> 30 <616b> 20 <6520626f6c6420656666> 30 <656374>] TJ
+ET
+
+
+BT
+86.05 636.0 Td
+/F1.0 12 Tf
+[<536f6d652063686172> 10 <6163746572732074686174206f> 15 <76> 25 <6572> -15 <6c617020776974682064696666> 30 <6572656e74205820746f206163686965> 30 <76> 25 <6520612066> 30 <616b> 20 <6520626f6c6420656666> 30 <656374>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612.0 792.0]
+/CropBox [0 0 612.0 792.0]
+/BleedBox [0 0 612.0 792.0]
+/TrimBox [0 0 612.0 792.0]
+/ArtBox [0 0 612.0 792.0]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000778 00000 n 
+0000001064 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+1161
+%%EOF

--- a/spec/data/overlapping-chars-xy-fake-bold.pdf
+++ b/spec/data/overlapping-chars-xy-fake-bold.pdf
@@ -1,0 +1,80 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 538
+>>
+stream
+q
+
+BT
+85.95 635.95 Td
+/F1.0 12 Tf
+[<536f6d652063686172> 10 <6163746572732074686174206f> 15 <76> 25 <6572> -15 <6c617020776974682064696666> 30 <6572656e74205820616e64205920746f206163686965> 30 <76> 25 <6520612066> 30 <616b> 20 <6520626f6c6420656666> 30 <656374>] TJ
+ET
+
+
+BT
+86.05 636.05 Td
+/F1.0 12 Tf
+[<536f6d652063686172> 10 <6163746572732074686174206f> 15 <76> 25 <6572> -15 <6c617020776974682064696666> 30 <6572656e74205820616e64205920746f206163686965> 30 <76> 25 <6520612066> 30 <616b> 20 <6520626f6c6420656666> 30 <656374>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612.0 792.0]
+/CropBox [0 0 612.0 792.0]
+/BleedBox [0 0 612.0 792.0]
+/TrimBox [0 0 612.0 792.0]
+/ArtBox [0 0 612.0 792.0]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000804 00000 n 
+0000001090 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+1187
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1053,4 +1053,32 @@ describe PDF::Reader, "integration specs" do
       end
     end
   end
+
+  context "PDF with overlapping chars to achieve fake bold effect" do
+    let(:filename) { pdf_spec_file("overlapping-chars-xy-fake-bold") }
+    let(:text) {
+      "Some characters that overlap with different X and Y to achieve a fake bold effect"
+    }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to eq(text)
+      end
+    end
+  end
+
+  context "PDF with overlapping chars (same Y pos) to achieve fake bold effect" do
+    let(:filename) { pdf_spec_file("overlapping-chars-x-fake-bold") }
+    let(:text) {
+      "Some characters that overlap with different X to achieve a fake bold effect"
+    }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to eq(text)
+      end
+    end
+  end
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -257,6 +257,12 @@ data/osx_print_unicode.pdf:
 data/outline.pdf:
   :bytes: 6313
   :md5: 95a4ebc34a521001125040afc146cd2e
+data/overlapping-chars-x-fake-bold.pdf:
+  :bytes: 1377
+  :md5: f53f3cbbaffffa5039408cb2e5a0a572
+data/overlapping-chars-xy-fake-bold.pdf:
+  :bytes: 1403
+  :md5: 2c9d673b612514e2a4f1be5cb11510a0
 data/override_inherited_attributes.pdf:
   :bytes: 1140
   :md5: d0d37dce31110dc5ba6b85d0c0dba608

--- a/spec/overlapping_runs_filter_spec.rb
+++ b/spec/overlapping_runs_filter_spec.rb
@@ -1,0 +1,46 @@
+# coding: utf-8
+
+describe PDF::Reader::OverlappingRunsFilter, "#exclude_redundant_runs" do
+
+  let(:result) {
+    PDF::Reader::OverlappingRunsFilter.exclude_redundant_runs(runs)
+  }
+
+  context "when there's a single run" do
+    let(:runs) do
+      [
+        PDF::Reader::TextRun.new(30, 700, 50, 12, "")
+      ]
+    end
+
+    it "returns the run unmodified" do
+      expect(result).to match_array(runs)
+    end
+  end
+
+  context "when there's two non-overlapping runs" do
+    let(:runs) do
+      [
+        PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+        PDF::Reader::TextRun.new(30, 676, 50, 12, "World"),
+      ]
+    end
+
+    it "returns the run unmodified" do
+      expect(result).to match_array(runs)
+    end
+  end
+
+  context "when there's two identical runs" do
+    let(:runs) do
+      [
+        PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+        PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+      ]
+    end
+
+    it "returns only one of the runs" do
+      expect(result).to match_array(runs.slice(0,1))
+    end
+  end
+end

--- a/spec/overlapping_runs_filter_spec.rb
+++ b/spec/overlapping_runs_filter_spec.rb
@@ -43,4 +43,71 @@ describe PDF::Reader::OverlappingRunsFilter, "#exclude_redundant_runs" do
       expect(result).to match_array(runs.slice(0,1))
     end
   end
+
+  context "when the second run overlaps the right edge of the first" do
+    context "by 50%" do
+      let(:runs) do
+        [
+          PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+          PDF::Reader::TextRun.new(55, 700, 50, 12, "Hello"),
+        ]
+      end
+      it "returns only one of the runs" do
+        expect(result).to match_array(runs.slice(0,1))
+      end
+    end
+    context "by less than 50%" do
+      let(:runs) do
+        [
+          PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+          PDF::Reader::TextRun.new(65, 700, 50, 12, "Hello"),
+        ]
+      end
+      it "returns only one of the runs" do
+        expect(result).to match_array(runs)
+      end
+    end
+  end
+
+  context "when the second run overlaps the left edge of the first" do
+    context "by 50%" do
+      let(:runs) do
+        [
+          PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+          PDF::Reader::TextRun.new(5, 700, 50, 12, "Hello"),
+        ]
+      end
+      it "returns only one of the runs" do
+        expect(result).to match_array(runs.slice(1,1))
+      end
+    end
+  end
+
+  context "when the second run overlaps the top edge of the first" do
+    context "by 50%" do
+      let(:runs) do
+        [
+          PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+          PDF::Reader::TextRun.new(30, 706, 50, 12, "Hello"),
+        ]
+      end
+      it "returns only one of the runs" do
+        expect(result).to match_array(runs.slice(0,1))
+      end
+    end
+  end
+
+  context "when the second run overlaps the bottom edge of the first" do
+    context "by 50%" do
+      let(:runs) do
+        [
+          PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+          PDF::Reader::TextRun.new(30, 694, 50, 12, "Hello"),
+        ]
+      end
+      it "returns only one of the runs" do
+        expect(result).to match_array(runs.slice(0,1))
+      end
+    end
+  end
 end

--- a/spec/page_layout_spec.rb
+++ b/spec/page_layout_spec.rb
@@ -160,6 +160,46 @@ describe PDF::Reader::PageLayout do
           expect(subject.to_s).to eq("Hello World")
         end
       end
+
+      context "with two runs that overlap to make fake 'bold', using the same Y offset" do
+        let!(:runs) do
+          [
+            PDF::Reader::TextRun.new(420.74, 636.0, 6.67, 12, "b"),
+            PDF::Reader::TextRun.new(427.41, 636.0, 6.67, 12, "o"),
+            PDF::Reader::TextRun.new(434.08, 636.0, 2.66, 12, "l"),
+            PDF::Reader::TextRun.new(436.75, 636.0, 6.67, 12, "d"),
+            PDF::Reader::TextRun.new(420.84, 636.0, 6.67, 12, "b"),
+            PDF::Reader::TextRun.new(427.51, 636.0, 6.67, 12, "o"),
+            PDF::Reader::TextRun.new(434.18, 636.0, 2.66, 12, "l"),
+            PDF::Reader::TextRun.new(436.85, 636.0, 6.67, 12, "d"),
+          ]
+        end
+        subject { PDF::Reader::PageLayout.new(runs, mediabox)}
+
+        it "returns a correct string" do
+          expect(subject.to_s).to eq("bold")
+        end
+      end
+
+      context "with two runs that overlap to make fake 'bold', using different X+Y offset" do
+        let!(:runs) do
+          [
+            PDF::Reader::TextRun.new(420.74, 635.95, 6.67, 12, "b"),
+            PDF::Reader::TextRun.new(427.41, 635.95, 6.67, 12, "o"),
+            PDF::Reader::TextRun.new(434.08, 635.95, 2.66, 12, "l"),
+            PDF::Reader::TextRun.new(436.75, 635.95, 6.67, 12, "d"),
+            PDF::Reader::TextRun.new(420.84, 636.05, 6.67, 12, "b"),
+            PDF::Reader::TextRun.new(427.51, 636.05, 6.67, 12, "o"),
+            PDF::Reader::TextRun.new(434.18, 636.05, 2.66, 12, "l"),
+            PDF::Reader::TextRun.new(436.85, 636.05, 6.67, 12, "d"),
+          ]
+        end
+        subject { PDF::Reader::PageLayout.new(runs, mediabox)}
+
+        it "returns a correct string" do
+          expect(subject.to_s).to eq("bold")
+        end
+      end
     end
   end
 end

--- a/spec/text_run_spec.rb
+++ b/spec/text_run_spec.rb
@@ -282,4 +282,28 @@ describe PDF::Reader::TextRun do
       end
     end
   end
+
+  describe "#intersection_area_percent" do
+    let(:result) {
+      run_one.intersection_area_percent(run_two)
+    }
+
+    context "with two runs that don't intersect" do
+      let(:run_one) { PDF::Reader::TextRun.new(30, 700, 10, 12, "H") }
+      let(:run_two) { PDF::Reader::TextRun.new(100, 500, 10, 12, "H") }
+
+      it "returns 0" do
+        expect(result).to eq(0)
+      end
+    end
+
+    context "when run_two overalps with 50% of run_one" do
+      let(:run_one) { PDF::Reader::TextRun.new(100, 100, 10, 12, "H") }
+      let(:run_two) { PDF::Reader::TextRun.new(105, 100, 10, 12, "H") }
+
+      it "returns 0.5" do
+        expect(result).to be_within(0.01).of(0.5)
+      end
+    end
+  end
 end

--- a/spec/text_run_spec.rb
+++ b/spec/text_run_spec.rb
@@ -222,4 +222,64 @@ describe PDF::Reader::TextRun do
       end
     end
   end
+
+  describe "#intersect" do
+    let(:result) {
+      run_one.intersect?(run_two)
+    }
+
+    context "with two runs that don't intersect" do
+      let(:run_one) { PDF::Reader::TextRun.new(30, 700, 10, 12, "H") }
+      let(:run_two) { PDF::Reader::TextRun.new(100, 500, 10, 12, "H") }
+
+      it "returns false" do
+        expect(result).to eq(false)
+      end
+    end
+
+    context "when run_two overlaps the top of run_one" do
+      let(:run_one) { PDF::Reader::TextRun.new(30, 100, 10, 12, "H") }
+      let(:run_two) { PDF::Reader::TextRun.new(30, 110, 10, 12, "H") }
+
+      it "returns true" do
+        expect(result).to eq(true)
+      end
+    end
+
+    context "when run_two overlaps the bottom of run_one" do
+      let(:run_one) { PDF::Reader::TextRun.new(30, 100, 10, 12, "H") }
+      let(:run_two) { PDF::Reader::TextRun.new(30, 92, 10, 12, "H") }
+
+      it "returns true" do
+        expect(result).to eq(true)
+      end
+    end
+
+    context "when run_two overlaps the left of run_one" do
+      let(:run_one) { PDF::Reader::TextRun.new(30, 100, 10, 12, "H") }
+      let(:run_two) { PDF::Reader::TextRun.new(25, 100, 10, 12, "H") }
+
+      it "returns true" do
+        expect(result).to eq(true)
+      end
+    end
+
+    context "when run_two overlaps the right of run_one" do
+      let(:run_one) { PDF::Reader::TextRun.new(30, 100, 10, 12, "H") }
+      let(:run_two) { PDF::Reader::TextRun.new(35, 100, 10, 12, "H") }
+
+      it "returns true" do
+        expect(result).to eq(true)
+      end
+    end
+
+    context "with two identical runs" do
+      let(:run_one) { PDF::Reader::TextRun.new(30, 700, 10, 12, "H") }
+      let(:run_two) { PDF::Reader::TextRun.new(30, 700, 10, 12, "H") }
+
+      it "returns true" do
+        expect(result).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some PDF producers will overlap identical characters (often offset by a small amount) to achieve a fake "bold" effect in the text.

This updates the PageLayout class to ignore the duplicates, provided they overlap by at least 50%.

This seems to work fairly well, but I'm interested in feedback from folks that can run this against real world files.

There's also a performance hit to looking for overlapping characters. I've optimised it a fair amount, but no doubt there's more that could be done. I'm open to improving it further if feedback suggests the performance is a problem.

Closes #143