### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -15,8 +15,15 @@ Gem::Specification.new do |spec|
                        '--main'  << 'README.md' << '-q'
   spec.authors = ["James Healy"]
   spec.email   = ["james@yob.id.au"]
-  spec.homepage = "http://github.com/yob/pdf-reader"
+  spec.homepage = "https://github.com/yob/pdf-reader"
   spec.required_ruby_version = ">=1.9.3"
+
+  spec.metadata = {
+    "bug_tracker_uri"   => "https://github.com/yob/pdf-reader/issues",
+    "changelog_uri"     => "https://github.com/yob/pdf-reader/blob/v#{spec.version}/CHANGELOG",
+    "documentation_uri" => "https://www.rubydoc.info/gems/pdf-reader/#{spec.version}",
+    "source_code_uri"   => "https://github.com/yob/pdf-reader/tree/v#{spec.version}",
+  }
 
   spec.add_development_dependency("rake")
   spec.add_development_dependency("rspec", "~> 3.5")


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/pdf-reader), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.

Also update the homepage URL to use TLS.