### PR TITLE
Silence warning for "unused variable -ex"

### DIFF
--- a/lib/pdf/reader.rb
+++ b/lib/pdf/reader.rb
@@ -180,7 +180,7 @@ module PDF
       (1..self.page_count).map do |num|
         begin
           PDF::Reader::Page.new(@objects, num, :cache => @cache)
-        rescue InvalidPageError => ex
+        rescue InvalidPageError
           raise MalformedPDFError, "Missing data for page: #{num}"
         end
       end


### PR DESCRIPTION
When running with warnings enabled, lib/pdf/reader.rb gives this warning:

    /home/wayne/homesmart/pdf-reader/lib/pdf/reader.rb:183: warning: assigned but unused variable - ex

This simply removes the unused variable binding, silencing the warning.