### PR TITLE
Overlapping character detection should be nlog(n) instead of  n²

### DIFF
--- a/lib/pdf/reader/overlapping_runs_filter.rb
+++ b/lib/pdf/reader/overlapping_runs_filter.rb
@@ -21,13 +21,12 @@ class PDF::Reader
 
       event_point_schedule.sort! { |a,b| a.x <=> b.x }
 
-      while not event_point_schedule.empty? do
-        event_point = event_point_schedule.shift
-        break unless event_point
+      event_point_schedule.each do |event_point|
+        run = event_point.run
 
-        if event_point.start? then
+        if event_point.start?
           if detect_intersection(sweep_line_status, event_point)
-            to_exclude << event_point.run
+            to_exclude << run
           end
           sweep_line_status.push event_point
         else

--- a/lib/pdf/reader/overlapping_runs_filter.rb
+++ b/lib/pdf/reader/overlapping_runs_filter.rb
@@ -28,19 +28,19 @@ class PDF::Reader
           if detect_intersection(sweep_line_status, event_point)
             to_exclude << run
           end
-          sweep_line_status.push event_point
+          sweep_line_status.push(run)
         else
-          sweep_line_status.delete event_point
+          sweep_line_status.delete(run)
         end
       end
       runs - to_exclude
     end
 
     def self.detect_intersection(sweep_line_status, event_point)
-      sweep_line_status.each do |point_in_sls|
-        if event_point.x >= point_in_sls.run.x &&
-            event_point.x <= point_in_sls.run.endx &&
-            point_in_sls.run.intersection_area_percent(event_point.run) >= OVERLAPPING_THRESHOLD
+      sweep_line_status.each do |open_text_run|
+        if event_point.x >= open_text_run.x &&
+            event_point.x <= open_text_run.endx &&
+            open_text_run.intersection_area_percent(event_point.run) >= OVERLAPPING_THRESHOLD
           return true
         end
       end


### PR DESCRIPTION
In #306, @MathieuDerelle flagged the text overlapping logic performs very slowly on some PDFs.

The root cause in his case was missing font metrics (see #307), but while investigating I discovered the overlapping detection was [accidentally quadratic](https://accidentallyquadratic.tumblr.com/) when it should be `n . log(n)`.

The detection intentionally has nested loops over the characters on a page. The naive approach would be something like this:

```ruby
characters.each do |outer_char|
  characters.each do |inner_char|
    if outer_char <> inner_char && inner_char.overlaps_with?(outer_char)
      # discard one of them
    end
  end
end
``` 

That approach would be n² though.

On master we make an attempt to shorten the inner loop and only examine characters that have a chance of overlapping with the character from the outer loop.

However, I accidentally wasn't removing items from the inner loop properly. That meant on each iteration of the outer loop the inner loop got longer and longer, until it was eventually roughly as long as the outer loop. Making the overall algorithm approximately n² anyway.

With this change the inner loop is kept short and performance should be closer to `n . log(n)`.

Here's a chart of the number of executions of the inner loop on master and this branch, given increasing numbers of characters on a page.

![Screenshot from 2019-11-14 15-03-24](https://user-images.githubusercontent.com/8132/68826171-d98c7500-06f0-11ea-8cba-ed27ed7cf955.png)
