### PR TITLE
Fallback to a substitute font for Type1 and TrueType fonts that aren't embedded

### DIFF
--- a/lib/pdf/reader/font.rb
+++ b/lib/pdf/reader/font.rb
@@ -97,7 +97,13 @@ class PDF::Reader
       elsif @subtype == :Type3
         PDF::Reader::WidthCalculator::TypeOneOrThree.new(self)
       elsif @subtype == :TrueType
-        PDF::Reader::WidthCalculator::TrueType.new(self)
+        if @font_descriptor
+          PDF::Reader::WidthCalculator::TrueType.new(self)
+        else
+          # A TrueType font that isn't embedded. Most readers look for a version on the
+          # local system and fallback to a substitute. For now, we go straight to a substitute
+          PDF::Reader::WidthCalculator::BuiltIn.new(self)
+        end
       elsif @subtype == :CIDFontType0 || @subtype == :CIDFontType2
         PDF::Reader::WidthCalculator::Composite.new(self)
       else

--- a/lib/pdf/reader/width_calculator/built_in.rb
+++ b/lib/pdf/reader/width_calculator/built_in.rb
@@ -12,11 +12,20 @@ class PDF::Reader
     # see Section 9.6.2.2, PDF 32000-1:2008, pp 256
     class BuiltIn
 
+      BUILTINS = [
+        :Courier, :"Courier-Bold", :"Courier-BoldOblique", :"Courier-Oblique",
+        :Helvetica, :"Helvetica-Bold", :"Helvetica-BoldOblique", :"Helvetica-Oblique",
+        :Symbol,
+        :"Times-Roman", :"Times-Bold", :"Times-BoldItalic", :"Times-Italic",
+        :ZapfDingbats
+      ]
+
       def initialize(font)
         @font = font
         @@all_metrics ||= PDF::Reader::SynchronizedCache.new
 
-        metrics_path = File.join(File.dirname(__FILE__), "..","afm","#{font.basefont}.afm")
+        basefont = extract_basefont(font.basefont)
+        metrics_path = File.join(File.dirname(__FILE__), "..","afm","#{basefont}.afm")
 
         if File.file?(metrics_path)
           @metrics = @@all_metrics[metrics_path] ||= AFM::Font.new(metrics_path)
@@ -54,6 +63,13 @@ class PDF::Reader
         @font.encoding.int_to_name(code_point).first.to_s[/\Acontrol..\Z/]
       end
 
+      def extract_basefont(font_name)
+        if BUILTINS.include?(font_name)
+          font_name
+        else
+          "Times-Roman"
+        end
+      end
     end
   end
 end

--- a/spec/data/truetype-arial.pdf
+++ b/spec/data/truetype-arial.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 523
+>>
+stream
+q
+
+BT
+36.0 747.804 Td
+/F1.0 12 Tf
+[<54686973207465> 15 <7874207573657320612054> 35 <72756554> 80 <79706520666f6e7420746861742069736e277420656d6265646465642e>] TJ
+ET
+
+
+BT
+36.0 734.412 Td
+/F1.0 12 Tf
+[<4d6f73742050444620726561646572732077696c6c206c6f6f6b20666f72206120666f6e742077697468207468652073616d65206e616d65206f6e20746865206c6f63616c2073797374656d2c20616e642066> 10 <616c6c6261636b20746f206120276265737420677565737327>] TJ
+ET
+
+
+BT
+36.0 721.02 Td
+/F1.0 12 Tf
+[<737562737469747574652069662072657175697265642e>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612.0 792.0]
+/CropBox [0 0 612.0 792.0]
+/BleedBox [0 0 612.0 792.0]
+/TrimBox [0 0 612.0 792.0]
+/ArtBox [0 0 612.0 792.0]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /TrueType
+/BaseFont /Arial
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000789 00000 n 
+0000001075 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+1171
+%%EOF

--- a/spec/data/type1-arial.pdf
+++ b/spec/data/type1-arial.pdf
@@ -1,0 +1,73 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 154
+>>
+stream
+q
+
+BT
+36.0 747.804 Td
+/F1.0 12 Tf
+[<54686973207465> 15 <7874207573657320612054> 80 <7970653120666f6e7420746861742069736e277420656d626564646564>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612.0 792.0]
+/CropBox [0 0 612.0 792.0]
+/BleedBox [0 0 612.0 792.0]
+/TrimBox [0 0 612.0 792.0]
+/ArtBox [0 0 612.0 792.0]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Arial
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000420 00000 n 
+0000000706 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+799
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -887,6 +887,28 @@ describe PDF::Reader, "integration specs" do
     end
   end
 
+  context "PDF that uses a type1 font that isn't embedded and isn't one of the 14 built-ins" do
+    let(:filename) { pdf_spec_file("type1-arial") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to eq("This text uses a Type1 font that isn't embedded")
+      end
+    end
+  end
+
+  context "PDF that uses a TrueType font that isn't embedded and has no metrics" do
+    let(:filename) { pdf_spec_file("truetype-arial") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to start_with("This text uses a TrueType font that isn't embedded")
+      end
+    end
+  end
+
   context "PDF that uses a type3 bitmap font" do
     let(:filename) { pdf_spec_file("type3_font") }
 

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -326,6 +326,12 @@ data/symbol.pdf:
 data/times-with-control-character.pdf:
   :bytes: 904
   :md5: 4bd7309a3f190ede68a88bb2be8bf237
+data/truetype-arial.pdf:
+  :bytes: 1387
+  :md5: 2b3e4ff85b618d1f4c6b3b5df2631ab0
+data/type1-arial.pdf:
+  :bytes: 1014
+  :md5: eb48405005f1265219c4c8759eafee32
 data/type3_font.pdf:
   :bytes: 2203
   :md5: ef2a3eb57d5996c4a33681e1aec98f2c

--- a/spec/width_calculator/built_in_spec.rb
+++ b/spec/width_calculator/built_in_spec.rb
@@ -6,28 +6,6 @@ describe PDF::Reader::WidthCalculator::BuiltIn do
     subject     { PDF::Reader::WidthCalculator::BuiltIn.new(font)}
   end
 
-  describe "#initialize" do
-    context "when the basefont is one of the 14 standard fonts" do
-      let!(:font)        { double(:basefont => :Helvetica) }
-
-      it "initializes with no errors" do
-        expect {
-          PDF::Reader::WidthCalculator::BuiltIn.new(font)
-        }.not_to raise_error
-      end
-    end
-
-    context "when the basefont is not one of the 14 standard fonts" do
-      let!(:font)        { double(:basefont => :Foo) }
-
-      it "raises an error" do
-        expect {
-          PDF::Reader::WidthCalculator::BuiltIn.new(font)
-        }.to raise_error(ArgumentError)
-      end
-    end
-  end
-
   describe "#glyph_width" do
     context "With Helvetica, StandardEncoding and no Widths" do
       let!(:encoding)     { PDF::Reader::Encoding.new(:StandardEncoding) }
@@ -46,6 +24,22 @@ describe PDF::Reader::WidthCalculator::BuiltIn do
 
       it "returns width 0 for code point 157(unknown)" do
         expect(width_calculator.glyph_width(157)).to eq(0)
+      end
+    end
+
+    context "With Foo, a font that isn't part of the built-in 14" do
+      let!(:encoding)     { PDF::Reader::Encoding.new(:WinAnsiEncoding) }
+      let!(:font)         { double(:basefont => :Foo,
+                                  :subtype => :Type1,
+                                  :encoding => encoding,
+                                  :widths => []) }
+
+      let(:width_calculator) {
+        PDF::Reader::WidthCalculator::BuiltIn.new(font)
+      }
+
+      it "returns width 722 for code point 65 (A)" do
+        expect(width_calculator.glyph_width(65)).to eq(722)
       end
     end
   end


### PR DESCRIPTION
Some PDFs use fonts that aren't embedded and are either:

* Type1, yet aren't one of the 14 "built in" fonts that PDF readers are expected to support
* TrueType, and PDF readers will attempt to find a font with the same name on the local system. If there's no match, an approximate substitute will be used.

In these situations we've raised an exception. That's frustrating for users and not what other readers do, so this changes pdf-reader to perform a font substitution.

For now the substitution is super-simple. We don't look for a matching font on the local system, we just use the font metrics for the built-in Times-Roman font.

That might be enough for now. pdf-reader isn't attempting to render any pages visually, so we only need the substitute for glyph metrics (like width).

## TODO

* [x] integration spec for a Type1 font that isn't built-in
* [x] integration spec for a TrueType font that isn't built-in

Closes #292
Closes #307