### PR TITLE
Allow Pipes for STDIN

### DIFF
--- a/bin/pdf_callbacks
+++ b/bin/pdf_callbacks
@@ -9,7 +9,7 @@ require 'pdf/reader'
 receiver = PDF::Reader::PrintReceiver.new
 
 if ARGV.empty?
-  browser = PDF::Reader.new($stdin)
+  browser = PDF::Reader.new(StringIO.new(ARGF.read))
 else
   browser = PDF::Reader.new(ARGV[0])
 end

--- a/bin/pdf_text
+++ b/bin/pdf_text
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'pdf/reader'
 
 if ARGV.empty?
-  browser = PDF::Reader.new($stdin)
+  browser = PDF::Reader.new(StringIO.new(ARGF.read))
 else
   browser = PDF::Reader.new(ARGV[0])
 end


### PR DESCRIPTION
This fixes #310

Now all 3 of these commands are supported:

```
cat my_pdf.pdf | bin/pdf_text
bin/pdf_text my_pdf.pdf
bin/pdf_text < my_pdf.pdf
```