### PR TITLE
require specs to pass on MRI 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
-  - 2.7.0-preview2
+  - 2.7
   - jruby-9.1
   - jruby-9.2
 before_install:
   - gem update bundler
-matrix:
-  allow_failures:
-  - rvm: 2.7.0-preview2


### PR DESCRIPTION
2.7 has been released and the specs  are green - this will keep them that way