### PR TITLE
use abs values for width/height

### DIFF
--- a/lib/pdf/reader/orientation_detector.rb
+++ b/lib/pdf/reader/orientation_detector.rb
@@ -22,8 +22,8 @@ class PDF::Reader
     def detect_orientation
       llx,lly,urx,ury = @attributes[:MediaBox]
       rotation        = @attributes[:Rotate].to_i
-      width           = urx.to_i - llx.to_i
-      height          = ury.to_i - lly.to_i
+      width           = (urx.to_i - llx.to_i).abs
+      height          = (ury.to_i - lly.to_i).abs
       if width > height
         (rotation % 180).zero? ? 'landscape' : 'portrait'
       else


### PR DESCRIPTION
I was having issues where pages that had a `MediaBox` is returning `[0,792,612,0]` instead of `[0,0,612,792]` for some PDFs. So it renders in portrait mode but `pdf-reader` is returning an orientation of `landscape` since the `height` is coming back negative making `width > height` true. A negative value seems like a non-sensible value in general since a width or height shouldn't be negative so I changed to do an `abs` on the value returned.