### PR TITLE
Don't apply character/word spacing to individual glyph displacement by the TJ operator

### DIFF
--- a/lib/pdf/reader/page_state.rb
+++ b/lib/pdf/reader/page_state.rb
@@ -330,11 +330,13 @@ class PDF::Reader
         th = state[:h_scaling]
         # optimise the common path to reduce Float allocations
         if th == 1 && tj == 0 && tc == 0 && tw == 0
-          glyph_width = w0 * fs
-          tx = glyph_width
+          tx = w0 * fs
+        elsif tj != 0
+          # don't apply spacing to TJ displacement
+          tx = (w0 - (tj/1000.0)) * fs * th
         else
-          glyph_width = ((w0 - (tj/1000.0)) * fs) * th
-          tx = glyph_width + ((tc + tw) * th)
+          # apply horizontal scaling to spacing values but not font size
+          tx = ((w0 * fs) + tc + tw) * th
         end
 
         # TODO: I'm pretty sure that tx shouldn't need to be divided by

--- a/spec/data/TJ_and_char_spacing.pdf
+++ b/spec/data/TJ_and_char_spacing.pdf
@@ -1,0 +1,73 @@
+%PDF-1.7
+%„¢¼Ú
+
+1 0 obj
+  <<
+  /Type /Catalog
+  /Pages 2 0 R
+  >>
+endobj
+
+2 0 obj
+  <<
+  /Type /Pages
+  /Kids [3 0 R]
+  /Count 1
+  /MediaBox [0 0 595 842]
+  >>
+endobj
+
+3 0 obj
+  <<
+  /Type /Page
+  /Parent 2 0 R
+  /Resources 
+    <<
+    /Font 
+      <<
+      /F1 
+        <<
+        /Type /Font
+        /Subtype /Type1
+        /BaseFont /Helvetica
+        >>
+      >>
+    >>
+  /Contents 4 0 R
+  >>
+endobj
+
+4 0 obj
+  <<
+  /Length 279
+  >>
+stream
+  BT
+    /F1 18 Tf
+    1 0 0 1 50 800 Tm
+    18 TL
+    -2 Tc -1 Tw
+    (The big brown fox) Tj
+    T*
+    [(T)-108(h)-108(e)-162( )-108(b)-108(i)-108(g)-162( )-108(b)-108(r)-108(o)-108(w)-108(n)-162( )-108(f)-108(o)-108(x)] TJ
+    T*
+    0 Tc 0 Tw
+    (The big brown fox) Tj
+  ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000016 00000 n
+0000000074 00000 n
+0000000168 00000 n
+0000000405 00000 n
+trailer
+  <<
+  /Root 1 0 R
+  /Size 5
+  >>
+startxref
+740
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -982,6 +982,17 @@ describe PDF::Reader, "integration specs" do
     end
   end
 
+  context "PDF with a TJ operator that aims to correct for character spacing" do
+    let(:filename) { pdf_spec_file("TJ_and_char_spacing") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text[15,17]).to eq("The big brown fox")
+      end
+    end
+  end
+
   context "PDF with a page that's missing the MediaBox attribute" do
     let(:filename) { pdf_spec_file("mediabox_missing") }
 

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -2,12 +2,12 @@
 data/20070313 - 2nd Laptop Battery.pdf:
   :bytes: 27832
   :md5: be3427795b673615e42f89b9043d44d9
-data/TJ_starts_with_a_number.pdf:
-  :bytes: 13119
-  :md5: 83501b5c507cdddbd9283ad2003c885b
 data/TJ_and_char_spacing.pdf:
   :bytes: 905
   :md5: 8d2a7d485f95f3bc45187c1cf38330c2
+data/TJ_starts_with_a_number.pdf:
+  :bytes: 13119
+  :md5: 83501b5c507cdddbd9283ad2003c885b
 data/adobe_sample.pdf:
   :bytes: 378345
   :md5: 07ab19345bfd5d22af6301a5751f94c2
@@ -344,6 +344,9 @@ data/standard_font_with_a_difference.pdf:
 data/standard_font_with_no_difference.pdf:
   :bytes: 856
   :md5: 1d59995aefe22d8a8859c1c217dddcc9
+data/stream-with-extra-byte.z:
+  :bytes: 516
+  :md5: cb7b8af4921811eb51d1d22a4194a6fe
 data/surrogate_pair_integration_sample.pdf:
   :bytes: 1210387
   :md5: abc393e941d2aeb7a64f5e2ab1b58a92

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -5,6 +5,9 @@ data/20070313 - 2nd Laptop Battery.pdf:
 data/TJ_starts_with_a_number.pdf:
   :bytes: 13119
   :md5: 83501b5c507cdddbd9283ad2003c885b
+data/TJ_and_char_spacing.pdf:
+  :bytes: 905
+  :md5: 8d2a7d485f95f3bc45187c1cf38330c2
 data/adobe_sample.pdf:
   :bytes: 378345
   :md5: 07ab19345bfd5d22af6301a5751f94c2

--- a/spec/page_state_spec.rb
+++ b/spec/page_state_spec.rb
@@ -468,10 +468,10 @@ describe PDF::Reader::PageState do
                 it "alters the text matrix" do
                   state.process_glyph_displacement(2, 2, true)
 
-                  expect(state.trm_transform(0,0)).to eq([64.976, 700])
-                  expect(state.trm_transform(0,1)).to eq([64.976, 712])
-                  expect(state.trm_transform(1,0)).to eq([76.976, 700])
-                  expect(state.trm_transform(1,1)).to eq([76.976, 712])
+                  expect(state.trm_transform(0,0)).to eq([63.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([63.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([75.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([75.976, 712])
                 end
               end
             end
@@ -512,10 +512,10 @@ describe PDF::Reader::PageState do
                 it "alters the text matrix" do
                   state.process_glyph_displacement(2, 2, false)
 
-                  expect(state.trm_transform(0,0)).to eq([64.976, 700])
-                  expect(state.trm_transform(0,1)).to eq([64.976, 712])
-                  expect(state.trm_transform(1,0)).to eq([76.976, 700])
-                  expect(state.trm_transform(1,1)).to eq([76.976, 712])
+                  expect(state.trm_transform(0,0)).to eq([63.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([63.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([75.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([75.976, 712])
                 end
               end
               context "a word boundary" do
@@ -523,10 +523,10 @@ describe PDF::Reader::PageState do
                 it "alters the text matrix" do
                   state.process_glyph_displacement(2, 2, true)
 
-                  expect(state.trm_transform(0,0)).to eq([64.976, 700])
-                  expect(state.trm_transform(0,1)).to eq([64.976, 712])
-                  expect(state.trm_transform(1,0)).to eq([76.976, 700])
-                  expect(state.trm_transform(1,1)).to eq([76.976, 712])
+                  expect(state.trm_transform(0,0)).to eq([63.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([63.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([75.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([75.976, 712])
                 end
               end
             end
@@ -565,10 +565,10 @@ describe PDF::Reader::PageState do
                 it "alters the text matrix" do
                   state.process_glyph_displacement(2, 2, false)
 
-                  expect(state.trm_transform(0,0)).to eq([64.976, 700])
-                  expect(state.trm_transform(0,1)).to eq([64.976, 712])
-                  expect(state.trm_transform(1,0)).to eq([76.976, 700])
-                  expect(state.trm_transform(1,1)).to eq([76.976, 712])
+                  expect(state.trm_transform(0,0)).to eq([63.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([63.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([75.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([75.976, 712])
                 end
               end
               context "a word boundary" do
@@ -576,10 +576,10 @@ describe PDF::Reader::PageState do
                 it "alters the text matrix" do
                   state.process_glyph_displacement(2, 2, true)
 
-                  expect(state.trm_transform(0,0)).to eq([65.976, 700])
-                  expect(state.trm_transform(0,1)).to eq([65.976, 712])
-                  expect(state.trm_transform(1,0)).to eq([77.976, 700])
-                  expect(state.trm_transform(1,1)).to eq([77.976, 712])
+                  expect(state.trm_transform(0,0)).to eq([63.976, 700])
+                  expect(state.trm_transform(0,1)).to eq([63.976, 712])
+                  expect(state.trm_transform(1,0)).to eq([75.976, 700])
+                  expect(state.trm_transform(1,1)).to eq([75.976, 712])
                 end
               end
             end


### PR DESCRIPTION
We extract a lot of text from PDF files and I am currently trying to switch from `pdftotext` to this gem. There are cases in the wild where creators use weird (?) combinations of character/word spacing and individual glyph displacement via the `TJ` operator which visually cancel each other out. At least they do so in all the viewers I have tried. They do not so with the current implementation of `pdf-reader`. That's because here, character spacing is additionally applied to every `TJ` displacement, which seems to be wrong. The wording in the standard isn't exactly explicit about that but I find that my handcrafted test case proves me right.

![TJ_and_char_spacing](https://user-images.githubusercontent.com/11405612/106153711-20904a00-617f-11eb-9581-f1637564ed44.png)
The first line is compressed by a negative character/word spacing.
The second line has this effect reversed by individual glyph displacement via `TJ`.
The third line is normal text for reference.

The text output with current master is the following:
```
> puts reader.pages.first.text
Thebi brownfox
Thebi brownfox
The big brown fox
```
The text output with this PR applied is:
```
> puts reader.pages.first.text
Thebi brownfox
The big brown fox
The big brown fox
```

No other cases in the test suite are affected by this change except for the ones I corrected since they obviously expected the wrong behavior.

Please let me know if there is something wrong or missing in this pull request!