### PR TITLE
Lookup glyph metrics by name instead of codepoint

### DIFF
--- a/lib/pdf/reader/width_calculator/built_in.rb
+++ b/lib/pdf/reader/width_calculator/built_in.rb
@@ -37,24 +37,13 @@ class PDF::Reader
       def glyph_width(code_point)
         return 0 if code_point.nil? || code_point < 0
 
-        m = @metrics.char_metrics_by_code[code_point]
-        if m.nil?
-          names = @font.encoding.int_to_name(code_point)
+        names = @font.encoding.int_to_name(code_point)
+        metrics = names.map { |name|
+          @metrics.char_metrics[name.to_s]
+        }.compact.first
+        return metrics[:wx] if metrics
 
-          m = names.map { |name|
-            @metrics.char_metrics[name.to_s]
-          }.compact.first
-        end
-
-        if m
-          m[:wx]
-        elsif @font.widths[code_point - 1]
-          @font.widths[code_point - 1]
-        elsif control_character?(code_point)
-          0
-        else
-          0
-        end
+        @font.widths[code_point - 1] || 0
       end
 
       private

--- a/lib/pdf/reader/width_calculator/built_in.rb
+++ b/lib/pdf/reader/width_calculator/built_in.rb
@@ -41,9 +41,12 @@ class PDF::Reader
         metrics = names.map { |name|
           @metrics.char_metrics[name.to_s]
         }.compact.first
-        return metrics[:wx] if metrics
 
-        @font.widths[code_point - 1] || 0
+        if metrics
+          metrics[:wx]
+        else
+          @font.widths[code_point - 1] || 0
+        end
       end
 
       private

--- a/spec/width_calculator/built_in_spec.rb
+++ b/spec/width_calculator/built_in_spec.rb
@@ -27,6 +27,23 @@ describe PDF::Reader::WidthCalculator::BuiltIn do
       end
     end
 
+    context "With Helvetica and a custom encoding that overwrites standard codepoints" do
+      # Codepoint 196 (tilde) is mapped to German umlaut Ä
+      let(:encoding)     { PDF::Reader::Encoding.new({:Differences => [196, :Adieresis]}) }
+      let(:font)         { double(:basefont => :Helvetica,
+                                  :subtype => :Type1,
+                                  :encoding => encoding) }
+
+      let(:width_calculator) {
+        PDF::Reader::WidthCalculator::BuiltIn.new(font)
+      }
+
+      it "returns the correct width for the overwritten codepoint" do
+        # tilde = 333, Ä = 667
+        expect(width_calculator.glyph_width(196)).to eq(667)
+      end
+    end
+
     context "With Foo, a font that isn't part of the built-in 14" do
       let!(:encoding)     { PDF::Reader::Encoding.new(:WinAnsiEncoding) }
       let!(:font)         { double(:basefont => :Foo,


### PR DESCRIPTION
When writing PDFs with German text, for example, the built-in font encodings have to be extended to get access to Umlaut characters (äöüÄÖÜ). A sensible strategy, one would think, would be to use previously unused codepoints for that, as every built-in font has some of them. Most PDF creators probably do that, but I have had cases where a codepoint that was already mapped was reused. Because the lookup mechanism only uses the default mapping from the AFM files and has no clue about the `differences` in the PDF font encoding, the metrics for the default glyph are returned.
The width differences are small, of course. I wasn't able to craft a test PDF where the output of `page.text` would actually be wrong. The returned values of `WidthCalculator::BuiltIn#glyph_width` are incorrect nonetheless and it did make a difference in my custom `PageTextReceiver` where I work with the widths of the `TextRuns` (otherwise I clearly wouldn't have noticed).
I am not sure what your reasons were to introduce lookup by codepoint (performance maybe?). I tried to somehow preserve it as the default mechanism and only use the name lookup when the glyph code hasn't been mapped (as it is implemented now) **or** the encoding differences include it. But as far as I can see, the `Encoding#int_to_name` method mostly does exacly that, so there is little reason to anticipate it and then do it again.

I also shortened the last part of the `#glyph_width` method. If you don't agree with that I can undo it.