### PR TITLE
Fix exception in PageLayout when the page is too small to fit the text it holds

### DIFF
--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -30,6 +30,7 @@ class PDF::Reader
 
     def to_s
       return "" if @runs.empty?
+      return "" if row_count == 0
 
       page = row_count.times.map { |i| " " * col_count }
       @runs.each do |run|

--- a/spec/page_layout_spec.rb
+++ b/spec/page_layout_spec.rb
@@ -201,5 +201,15 @@ describe PDF::Reader::PageLayout do
         end
       end
     end
+    context "with a page that's too small to fit any of the text" do
+      let(:mediabox) { [0, 0, 46.560, 32.640]}
+      let(:font_size) { 72 }
+
+      it "returns an empty string" do
+        run = PDF::Reader::TextRun.new(0, 0, 50, font_size, "a")
+        layout = PDF::Reader::PageLayout.new([run], mediabox)
+        expect(layout.to_s).to eq("")
+      end
+    end
   end
 end


### PR DESCRIPTION
When the page has a 72pt character that would be bigger than the page, our current page layout algorithm assume the character shouldn't visible.

This fixed a crash, although maybe we could also debate whether dropping the character is the right behaviour?

Fixes #346