### PR TITLE
Apply page rotation to text after rendering, rather than before

### DIFF
--- a/lib/pdf/reader/page_state.rb
+++ b/lib/pdf/reader/page_state.rb
@@ -30,15 +30,7 @@ class PDF::Reader
         @xobject_stack = [page.xobjects]
         @cs_stack      = [page.color_spaces]
         @stack         = [DEFAULT_GRAPHICS_STATE.dup]
-        if page.rotate == 0
-          state[:ctm]  = identity_matrix
-        else
-          rotate_cos = Math.cos(page.rotate * (Math::PI/180.0)).round(2)
-          rotate_sin = Math.sin(page.rotate * (Math::PI/180.0)).round(2)
-          state[:ctm] = TransformationMatrix.new(rotate_cos, rotate_sin,
-                                                 rotate_sin * -1, rotate_cos,
-                                                 0, 0)
-        end
+        state[:ctm]  = identity_matrix
       end
 
       #####################################################

--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -41,6 +41,7 @@ module PDF
       # starting a new page
       def page=(page)
         @state = PageState.new(page)
+        @page = page
         @content = []
         @characters = []
         @mediabox = page.objects.deref(page.attributes[:MediaBox])
@@ -104,6 +105,8 @@ module PDF
         glyphs.each_with_index do |glyph_code, index|
           # paint the current glyph
           newx, newy = @state.trm_transform(0,0)
+          newx, newy = apply_rotation(newx, newy)
+
           utf8_chars = @state.current_font.to_utf8(glyph_code)
 
           # apply to glyph displacment for the current glyph so the next
@@ -116,6 +119,21 @@ module PDF
           end
           @state.process_glyph_displacement(glyph_width, 0, utf8_chars == SPACE)
         end
+      end
+
+      def apply_rotation(x, y)
+        if @page.rotate == 90
+          tmp = x
+          x = y
+          y = tmp * -1
+        elsif @page.rotate == 180
+          y *= -1
+        elsif @page.rotate == 270
+          tmp = x
+          x = y * -1
+          y = tmp * -1
+        end
+        return x, y
       end
 
     end

--- a/spec/data/rotate-90-then-undo.pdf
+++ b/spec/data/rotate-90-then-undo.pdf
@@ -1,0 +1,96 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 397
+>>
+stream
+0 1 -1 0 595 0 cm
+q
+BT
+36 559 Td
+ET
+Q
+2 J
+1 0 0 1 0 0 cm
+BT
+1 0 0 1 273.99 549.51 Tm
+/F1.0 12 Tf
+0 0 0 rg
+(1: This PDF has Rotate:90 in the page metadata)Tj
+0 g
+1 0 0 1 273.99 535.55 Tm
+0 0 0 rg
+(2: to get a landscape layout, and then uses matrix)Tj
+0 g
+1 0 0 1 273.99 521.59 Tm
+0 0 0 rg
+(3: transformation to rotate the text back to normal)Tj
+0 g
+ET
+
+BT
+36.0 797.384 Td
+/F1.0 12 Tf
+[<>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595 842]
+/Rotate 90
+/CropBox [0 0 595 842]
+/BleedBox [0 0 595 842]
+/TrimBox [0 0 595 842]
+/ArtBox [0 0 595 842]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000663 00000 n 
+0000000940 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+1037
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1197,4 +1197,20 @@ describe PDF::Reader, "integration specs" do
       end
     end
   end
+
+  context "PDF with page rotation of 90 degrees followed by matrix transformations to undo it" do
+    let(:filename) { pdf_spec_file("rotate-90-then-undo") }
+    let(:text) {
+      "1: This PDF has Rotate:90 in the page metadata\n" +
+      "2: to get a landscape layout, and then uses matrix\n" +
+      "3: transformation to rotate the text back to normal"
+    }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to eq(text)
+      end
+    end
+  end
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -326,6 +326,9 @@ data/prince2.pdf:
 data/rotate-180.pdf:
   :bytes: 17738
   :md5: 5ab145b4527aabb75532d9b990f6df0c
+data/rotate-90-then-undo.pdf:
+  :bytes: 1253
+  :md5: 198b5e4197643180a6d4e1659e7baf89
 data/rotate-then-undo.pdf:
   :bytes: 1191
   :md5: c14ac0c2669d63988c07c71f75c28b39


### PR DESCRIPTION
I originally added page rotation support in #317 and #318. They got specs passing, but as I've collected more sample PDFs I'm not sure the implementation was correct.

I has specs for 180 and 270 degree rotation, and this adds a new one for 90 degree rotation that's based on a real-world PDF is was provided privately.

The existing implementation didn't work with that file, but after some trial and error I found that applying the rotation after rendering the page state  works for all the sample PDFs I have.