### PR TITLE
bump min ruby version from 1.9.3 to 2.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,5 @@
 steps:
   - command: "auto/run-specs"
-    label: "rspec (1.9.3)"
-    env:
-      DOCKER_IMAGE: "ruby"
-      RUBY_VERSION: "1.9.3"
-
-  - command: "auto/run-specs"
     label: "rspec (2.0)"
     env:
       DOCKER_IMAGE: "ruby"

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["James Healy"]
   spec.email   = ["james@yob.id.au"]
   spec.homepage = "https://github.com/yob/pdf-reader"
-  spec.required_ruby_version = ">=1.9.3"
+  spec.required_ruby_version = ">=2.0"
 
   if spec.respond_to?(:metadata)
     spec.metadata = {


### PR DESCRIPTION
2.0 was released on 2013-02-24, 8 years ago. I know it's debatable that changing the supported ruby version is a breaking change that deserves a major version bump, but this is a one person project and I'm going to assume no one is running an 8 years old interpreter in production.