### PR TITLE
Use median instead of mean when determining page layout size

### DIFF
--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -86,14 +86,6 @@ class PDF::Reader
       end
     end
 
-    def each_line(&block)
-      @runs.sort.group_by { |run|
-        run.y.to_i
-      }.map { |y, collection|
-        yield y, collection
-      }
-    end
-
     # take a collection of TextRun objects and merge any that are in close
     # proximity
     def merge_runs(runs)

--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -20,7 +20,7 @@ class PDF::Reader
       @runs    = merge_runs(OverlappingRunsFilter.exclude_redundant_runs(runs))
       @mean_font_size   = mean(@runs.map(&:font_size)) || DEFAULT_FONT_SIZE
       @mean_font_size = DEFAULT_FONT_SIZE if @mean_font_size == 0
-      @mean_glyph_width = mean(@runs.map(&:mean_character_width)) || 0
+      @median_glyph_width = median(@runs.map(&:mean_character_width)) || 0
       @page_width  = (mediabox[2] - mediabox[0]).abs
       @page_height = (mediabox[3] - mediabox[1]).abs
       @x_offset = @runs.map(&:x).sort.first || 0
@@ -67,7 +67,7 @@ class PDF::Reader
     end
 
     def col_count
-      @col_count ||= ((@page_width  / @mean_glyph_width) * 1.05).floor
+      @col_count ||= ((@page_width  / @median_glyph_width) * 1.05).floor
     end
 
     def row_multiplier
@@ -83,6 +83,14 @@ class PDF::Reader
         0
       else
         collection.inject(0) { |accum, v| accum + v} / collection.size.to_f
+      end
+    end
+
+    def median(collection)
+      if collection.size == 0
+        0
+      else
+        collection.sort[(collection.size * 0.5).floor]
       end
     end
 


### PR DESCRIPTION
When extracting text from a page we're taking all the characters from that page (which can be a variety of sizes) and forcing them into a plain text string of a single size.

We have to determine the number of rows and columns in the plain text output, and we need enough of both to fit all the text.

To determine the number of columns I've been using the mean/average of the character widths on the page. That mostly works OK, but on pages with a handful of large characters (like headings) the mean/average can skew high. By using median, we can be confident about 50% of the text runs have characters at least as wide as the number we use to calculate columns in the output.

This is still a super naive algorithm. It's good enough for the basic approach though, and anyone with more advanced needs will still need to build their own layout algorithm.

In the long term, it'd be nice to change this algorithm to avoid silently over-writing characters.

Partial fix for #354 