### PR TITLE
Apply page rotation when calculating page dimensions for text extraction

### DIFF
--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -45,8 +45,8 @@ module PDF
         @content = []
         @characters = []
         @mediabox = page.objects.deref(page.attributes[:MediaBox])
-        device_bl = @state.ctm_transform(@mediabox[0], @mediabox[1])
-        device_tr = @state.ctm_transform(@mediabox[2], @mediabox[3])
+        device_bl = apply_rotation(*@state.ctm_transform(@mediabox[0], @mediabox[1]))
+        device_tr = apply_rotation(*@state.ctm_transform(@mediabox[2], @mediabox[3]))
         @device_mediabox = [ device_bl.first, device_bl.last, device_tr.first, device_tr.last]
       end
 

--- a/spec/data/rotate-90-then-undo-with-br-text.pdf
+++ b/spec/data/rotate-90-then-undo-with-br-text.pdf
@@ -1,0 +1,96 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 347
+>>
+stream
+0 1 -1 0 595 0 cm
+q
+BT
+36 559 Td
+ET
+Q
+2 J
+1 0 0 1 0 0 cm
+BT
+1 0 0 1 50.99 71.59 Tm
+/F1.0 12 Tf
+0 0 0 rg
+(This PDF has Rotate:90 in the page)Tj
+0 g
+1 0 0 1 350.99 71.59 Tm
+0 0 0 rg
+(metadata to get a landscape layout)Tj
+0 g
+1 0 0 1 650.99 71.59 Tm
+0 0 0 rg
+(and text in bottom right quadrant)Tj
+0 g
+ET
+
+BT
+36.0 797.384 Td
+/F1.0 12 Tf
+[<>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595 842]
+/Rotate 90
+/CropBox [0 0 595 842]
+/BleedBox [0 0 595 842]
+/TrimBox [0 0 595 842]
+/ArtBox [0 0 595 842]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000613 00000 n 
+0000000890 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+987
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1213,4 +1213,17 @@ describe PDF::Reader, "integration specs" do
       end
     end
   end
+
+  context "PDF with page rotation of 90 degrees followed by matrix transformations to undo it" do
+    let(:filename) { pdf_spec_file("rotate-90-then-undo-with-br-text") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to include("This PDF ha s Rotate:90 in the page")
+        expect(page.text).to include("metadata to get a landscape layout")
+        expect(page.text).to include("and text in bottom right quadrant")
+      end
+    end
+  end
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -326,6 +326,9 @@ data/prince2.pdf:
 data/rotate-180.pdf:
   :bytes: 17738
   :md5: 5ab145b4527aabb75532d9b990f6df0c
+data/rotate-90-then-undo-with-br-text.pdf:
+  :bytes: 1202
+  :md5: d86bb1a0cb9b2fdde5bb43d3f7cd1e9a
 data/rotate-90-then-undo.pdf:
   :bytes: 1253
   :md5: 198b5e4197643180a6d4e1659e7baf89


### PR DESCRIPTION
On pages with a Rotate property, we need to rotate the MediaBox when determining the page dimensions used to extract text.

Partial fix for #354 