### PR TITLE
Use optional ascii85_native gem when available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ http://groups.google.com/group/pdf-reader
 The easiest way to explain how this works in practice is to show some examples.
 Check out the examples/ directory for a few files.
 
+# Alternate Decoder
+
+For PDF files containing Ascii85 streams, the [ascii85_native](https://github.com/AnomalousBit/ascii85_native) gem can be used for increased performance. If the ascii85_native gem is detected, pdf-reader will automatically use the gem.
+
+First, run `gem install ascii85_native` and then require the gem alongside pdf-reader:
+
+```ruby
+require "pdf-reader"
+require "ascii85_native"
+```
+
+Another way of enabling native Ascii85 decoding is to place `gem 'ascii85_native'` in your project's `Gemfile`.
+
 # Known Limitations
 
 Occasionally some text cannot be extracted properly due to the way it has been

--- a/lib/pdf/reader/filter/ascii85.rb
+++ b/lib/pdf/reader/filter/ascii85.rb
@@ -16,6 +16,7 @@ class PDF::Reader
       # rubygem.
       #
       def filter(data)
+        data = "<~#{data}" unless data.to_s[0,2] == "<~"
         ::Ascii85Native::decode(data)
       rescue Exception => e
         # Oops, there was a problem decoding the stream

--- a/lib/pdf/reader/filter/ascii85.rb
+++ b/lib/pdf/reader/filter/ascii85.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 # frozen_string_literal: true
 
-require 'ascii85'
+require 'ascii85_native'
 
 class PDF::Reader
   module Filter # :nodoc:
@@ -17,7 +17,7 @@ class PDF::Reader
       #
       def filter(data)
         data = "<~#{data}" unless data.to_s[0,2] == "<~"
-        ::Ascii85::decode(data)
+        ::Ascii85Native::decode(data)
       rescue Exception => e
         # Oops, there was a problem decoding the stream
         raise MalformedPDFError,

--- a/lib/pdf/reader/filter/ascii85.rb
+++ b/lib/pdf/reader/filter/ascii85.rb
@@ -17,7 +17,11 @@ class PDF::Reader
       #
       def filter(data)
         data = "<~#{data}" unless data.to_s[0,2] == "<~"
-        ::Ascii85Native::decode(data)
+        if defined(::Ascii85Native)
+          ::Ascii85Native::decode(data)
+        else
+          ::Ascii85::decode(data)
+        end
       rescue Exception => e
         # Oops, there was a problem decoding the stream
         raise MalformedPDFError,

--- a/lib/pdf/reader/filter/ascii85.rb
+++ b/lib/pdf/reader/filter/ascii85.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 # frozen_string_literal: true
 
-require 'ascii85_native'
+require 'ascii85'
 
 class PDF::Reader
   module Filter # :nodoc:
@@ -17,7 +17,7 @@ class PDF::Reader
       #
       def filter(data)
         data = "<~#{data}" unless data.to_s[0,2] == "<~"
-        if defined(::Ascii85Native)
+        if defined?(::Ascii85Native)
           ::Ascii85Native::decode(data)
         else
           ::Ascii85::decode(data)

--- a/lib/pdf/reader/filter/ascii85.rb
+++ b/lib/pdf/reader/filter/ascii85.rb
@@ -16,7 +16,6 @@ class PDF::Reader
       # rubygem.
       #
       def filter(data)
-        data = "<~#{data}" unless data.to_s[0,2] == "<~"
         ::Ascii85Native::decode(data)
       rescue Exception => e
         # Oops, there was a problem decoding the stream

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("pry")
   spec.add_development_dependency("rdoc")
 
-  spec.add_dependency('ascii85_native', '~> 1.0')
+  spec.add_dependency('Ascii85', '~> 1.0')
   spec.add_dependency('ruby-rc4')
   spec.add_dependency('hashery', '~> 2.0')
   spec.add_dependency('ttfunk')

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("pry")
   spec.add_development_dependency("rdoc")
 
-  spec.add_dependency('Ascii85', '~> 1.0')
+  spec.add_dependency('ascii85_native', '~> 1.0')
   spec.add_dependency('ruby-rc4')
   spec.add_dependency('hashery', '~> 2.0')
   spec.add_dependency('ttfunk')


### PR DESCRIPTION
Per our conversation in https://github.com/yob/pdf-reader/issues/357 I've added the needed changes and documentation for optionally using the ascii85_native gem when it is present.

Thanks for the suggestions @yob and your wonderful gem.