### PR TITLE
Improve tiff stream decoding performance

### DIFF
--- a/lib/pdf/reader/filter/depredict.rb
+++ b/lib/pdf/reader/filter/depredict.rb
@@ -34,7 +34,7 @@ class PDF::Reader
       ################################################################################
       def tiff_depredict(data)
         data        = data.unpack("C*")
-        unfiltered  = []
+        unfiltered  = ''
         bpc         = @options[:BitsPerComponent] || 8
         pixel_bits  = bpc * @options[:Colors]
         pixel_bytes = pixel_bits / 8
@@ -51,11 +51,11 @@ class PDF::Reader
             left = index < pixel_bytes ? 0 : row_data[index - pixel_bytes]
             row_data[index] = (byte + left) % 256
           end
-          unfiltered += row_data
+          unfiltered += row_data.pack("C*")
           pos += line_len
         end
 
-        unfiltered.pack("C*")
+        unfiltered
       end
       ################################################################################
       def png_depredict(data)


### PR DESCRIPTION
Hi, thank you for the great gem.

I've found on some PDFs with large embedded TIFF assets,`tiff_depredict` gets really slow because of the cost of MRI's array appending operation on the buffer `unfiltered`. The profiler also shows the MRI's GC cost are also dominant here.
This PR uses string instead of array for buffering. In my particular case, the processing duration improved 15x (from 30 secs to 2 secs).