### PR TITLE
Also skip single CR chars in Buffer#read

### DIFF
--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -86,8 +86,8 @@ class PDF::Reader
     #
     # options:
     #
-    #   :skip_eol - if true, the IO stream is advanced past a CRLF or LF that
-    #               is sitting under the io cursor.
+    #   :skip_eol - if true, the IO stream is advanced past a CRLF, CR or LF
+    #               that is sitting under the io cursor.
     #
     def read(bytes, opts = {})
       reset_pos
@@ -99,7 +99,7 @@ class PDF::Reader
           return nil
         elsif str == "\r\n"
           # do nothing
-        elsif str[0,1] == "\n"
+        elsif str[0,1] == "\n" || str[0,1] == "\r"
           @io.seek(-1, IO::SEEK_CUR)
         else
           @io.seek(-2, IO::SEEK_CUR)

--- a/spec/data/content_stream_cr_only.pdf
+++ b/spec/data/content_stream_cr_only.pdf
@@ -1,0 +1,63 @@
+%PDF-1.7
+%„¢¼Ú
+
+1 0 obj
+  <<
+  /Type /Catalog
+  /Pages 2 0 R
+  >>
+endobj
+
+2 0 obj
+  <<
+  /Type /Pages
+  /Kids [3 0 R]
+  /Count 1
+  /MediaBox [0 0 595 842]
+  >>
+endobj
+
+3 0 obj
+  <<
+  /Type /Page
+  /Parent 2 0 R
+  /Resources 
+    <<
+    /Font 
+      <<
+      /F1 
+        <<
+        /Type /Font
+        /Subtype /Type1
+        /BaseFont /Helvetica
+        >>
+      >>
+    >>
+  /Contents 4 0 R
+  >>
+endobj
+
+4 0 obj
+  <<
+  /Length 77
+  >>
+streamBT
+    /F1 18 Tf
+    1 0 0 1 55 600 Tm
+    (This is a weird PDF file) Tj
+  ETendstreamendobj
+xref
+0 5
+0000000000 65535 f
+0000000016 00000 n
+0000000074 00000 n
+0000000168 00000 n
+0000000405 00000 n
+trailer
+  <<
+  /Root 1 0 R
+  /Size 5
+  >>
+startxref
+537
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -92,6 +92,17 @@ describe PDF::Reader, "integration specs" do
     end
   end
 
+  context "PDF with a content stream that is enclosed with CR characters only" do
+    let(:filename) { pdf_spec_file("content_stream_cr_only") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to eq("This is a weird PDF file")
+      end
+    end
+  end
+
   context "PDF with a content stream that is missing an operator (has hanging params)" do
     let(:filename) { pdf_spec_file("content_stream_missing_final_operator") }
 

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -74,6 +74,9 @@ data/content_stream_as_array.pdf:
 data/content_stream_begins_with_newline.pdf:
   :bytes: 910
   :md5: 6c447a7c6c99eb2b984ab2fd4c8d9c61
+data/content_stream_cr_only.pdf:
+  :bytes: 702
+  :md5: 3253e3654b2375bdd732d0dd1c096db9
 data/content_stream_missing_final_operator.pdf:
   :bytes: 46799
   :md5: 8b3d2706526dcf684dad80b53bf6dc94


### PR DESCRIPTION
It is valid to delimit the stream content from the stream/endstream keywords with only a CR instead of CRLF or LF. pdf-reader would crash in some cases until this change, as shown by the test case.