### PR TITLE
skip zero-width characters when rendering text to a page

### DIFF
--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'pdf/reader/overlapping_runs_filter'
+require 'pdf/reader/zero_width_runs_filter'
 
 class PDF::Reader
 
@@ -17,7 +18,9 @@ class PDF::Reader
     def initialize(runs, mediabox)
       raise ArgumentError, "a mediabox must be provided" if mediabox.nil?
 
-      @runs    = merge_runs(OverlappingRunsFilter.exclude_redundant_runs(runs))
+      runs = ZeroWidthRunsFilter.exclude_zero_width_runs(runs)
+      runs = OverlappingRunsFilter.exclude_redundant_runs(runs)
+      @runs = merge_runs(runs)
       @mean_font_size   = mean(@runs.map(&:font_size)) || DEFAULT_FONT_SIZE
       @mean_font_size = DEFAULT_FONT_SIZE if @mean_font_size == 0
       @median_glyph_width = median(@runs.map(&:mean_character_width)) || 0

--- a/lib/pdf/reader/zero_width_runs_filter.rb
+++ b/lib/pdf/reader/zero_width_runs_filter.rb
@@ -1,0 +1,11 @@
+# coding: utf-8
+
+class PDF::Reader
+  # There's no point rendering zero-width characters
+  class ZeroWidthRunsFilter
+
+    def self.exclude_zero_width_runs(runs)
+      runs.reject { |run| run.width == 0 }
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1182,7 +1182,7 @@ describe PDF::Reader, "integration specs" do
     it "extracts text correctly" do
       PDF::Reader.open(filename) do |reader|
         page = reader.page(1)
-        expect(page.text).to eq("aaaa\nbbbb")
+        expect(page.text).to eq("aaaabbbb")
       end
     end
   end


### PR DESCRIPTION
A spec added in #370 included a PDF that visually included the following text:

> aaaabbbb

... but the content stream included a zero-width LF character between aaaa and bbbb and pdf-reader text extraction looked like this:

> aaaa
> bbbb

This filters the zero-width LF out, so text output matches the visual appearance of the PDF:

> aaaabbbb