### PR TITLE
add build step for jruby 9.3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,3 +65,8 @@ steps:
       DOCKER_IMAGE: "jruby"
       RUBY_VERSION: "9.2"
 
+  - command: "auto/run-specs"
+    label: "rspec (jruby-9.3)"
+    env:
+      DOCKER_IMAGE: "jruby"
+      RUBY_VERSION: "9.3"


### PR DESCRIPTION
9.3 was released last month, targeting MRI 2.6 compatibility