### PR TITLE
Allow for incorrect start index in xref

### DIFF
--- a/lib/pdf/reader/xref.rb
+++ b/lib/pdf/reader/xref.rb
@@ -123,6 +123,12 @@ class PDF::Reader
     def load_xref_table(buf)
       params = []
 
+      # HACK: some PDF writers start numbering a 1 instead of 0. Fix up the number.
+      tokens = buf.instance_variable_get(:@tokens)
+      if tokens[0] == '1' and tokens[2] == '0000000000' and tokens[3] = '65535'
+        tokens[0] = "0"
+      end
+
       while !params.include?("trailer") && !params.include?(nil)
         if params.size == 2
           objid, count = params[0].to_i, params[1].to_i

--- a/lib/pdf/reader/xref.rb
+++ b/lib/pdf/reader/xref.rb
@@ -125,7 +125,8 @@ class PDF::Reader
 
       # HACK: some PDF writers start numbering a 1 instead of 0. Fix up the number.
       tokens = buf.instance_variable_get(:@tokens)
-      if tokens[0] == '1' and tokens[2] == '0000000000' and tokens[3] = '65535'
+      if tokens[0] == '1' and tokens[2, 3] == ['0000000000', '65535', 'f']
+        # TODO should this be logged?
         tokens[0] = "0"
       end
 

--- a/spec/data/minimal-xref-1.pdf
+++ b/spec/data/minimal-xref-1.pdf
@@ -1,0 +1,58 @@
+%PDF-1.1
+%¥±ë
+
+1 0 obj
+  << /Type /Catalog
+     /Pages 2 0 R
+  >>
+endobj
+
+2 0 obj
+  << /Type /Pages
+     /Kids [3 0 R]
+     /Count 1
+     /MediaBox [0 0 300 144]
+  >>
+endobj
+
+3 0 obj
+  <<  /Type /Page
+      /Parent 2 0 R
+      /Resources
+       << /Font
+           << /F1
+               << /Type /Font
+                  /Subtype /Type1
+                  /BaseFont /Times-Roman
+               >>
+           >>
+       >>
+      /Contents 4 0 R
+  >>
+endobj
+
+4 0 obj
+  << /Length 55 >>
+stream
+  BT
+    /F1 18 Tf
+    0 0 Td
+    (Hello World) Tj
+  ET
+endstream
+endobj
+
+xref
+1 5
+0000000000 65535 f 
+0000000018 00000 n 
+0000000077 00000 n 
+0000000178 00000 n 
+0000000457 00000 n 
+trailer
+  <<  /Root 1 0 R
+      /Size 5
+  >>
+startxref
+565
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1121,6 +1121,17 @@ describe PDF::Reader, "integration specs" do
     end
   end
 
+  context "PDF with bad xref: using 1 not 0" do
+    let(:filename) { pdf_spec_file("minimal-xref-1") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        page = reader.page(1)
+        expect(page.text).to eq("Hello World")
+      end
+    end
+  end
+
   context "PDF with octal data" do
     let(:filename) { pdf_spec_file("octal101") }
 

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -272,6 +272,9 @@ data/mediabox_missing.pdf:
 data/minimal.pdf:
   :bytes: 739
   :md5: b5808604069f9f61d94e0660409616ba
+data/minimal-xref-1.pdf:
+  :bytes: 739
+  :md5: c9ef70bcf0d39ce90e993b6aec606b42
 data/nested_form_xobject.pdf:
   :bytes: 30365
   :md5: 441fd2c734e81784d7db0a86bf4c11e5


### PR DESCRIPTION
Found several PDFs (unknown creator) with xref tables that start:

```
xref
1 <num>
0000000000 65535 f 
```
This should not happen, as the first entry in the first xref is always supposed to be 0.

These files open OK in the viewers I tried.

This PR adds a work-round to allow the files to be read.

I guess it might be worth logging a warning?