### PR TITLE
Anchor the match

### DIFF
--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -208,7 +208,7 @@ class PDF::Reader
     def load_mapping(file)
       File.open(file, "r:BINARY") do |f|
         f.each do |l|
-          _m, single_byte, unicode = *l.match(/([0-9A-Za-z]+);([0-9A-F]{4})/)
+          _m, single_byte, unicode = *l.match(/\A([0-9A-Za-z]+);([0-9A-F]{4})/)
           @mapping["0x#{single_byte}".hex] = "0x#{unicode}".hex if single_byte
         end
       end


### PR DESCRIPTION
Ensures commented entries are not processed
Should also speed matching as no need to scan entire line