### PR TITLE
define types for many of the common methods of the public API

### DIFF
--- a/auto/run-sorbet
+++ b/auto/run-sorbet
@@ -2,4 +2,13 @@
 #
 # Run the tests
 
-$(dirname $0)/with-ruby srb tc
+# Disable 7006 (https://sorbet.org/docs/error-reference#7006)
+# This error is sorbet warning about dead code. So far I've found this 
+# more harmful than helpful.
+#
+# A concrete example: I'm storing the type information in external rbi files, so the gem
+# doesn't pick up a runtime dependency on sorbet. However, that means I still need runtime
+# guard clauses in some methods to check the type or shape of an argument... but sorbet
+# considers these dead code. It thinks the type of the argument is guaranteed.
+
+$(dirname $0)/with-ruby srb tc --suppress-error-code 7006

--- a/lib/pdf/reader.rb
+++ b/lib/pdf/reader.rb
@@ -251,7 +251,7 @@ module PDF
     # String#encode
     #
     def utf16_to_utf8(obj)
-      str = obj[2, obj.size]
+      str = obj[2, obj.size].to_s
       str = str.unpack("n*").pack("U*")
       str.force_encoding("utf-8")
       str

--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -21,12 +21,11 @@ class PDF::Reader
 
       runs = ZeroWidthRunsFilter.exclude_zero_width_runs(runs)
       runs = OverlappingRunsFilter.exclude_redundant_runs(runs)
+      @mediabox = mediabox
       @runs = merge_runs(runs)
       @mean_font_size   = mean(@runs.map(&:font_size)) || DEFAULT_FONT_SIZE
       @mean_font_size = DEFAULT_FONT_SIZE if @mean_font_size == 0
       @median_glyph_width = median(@runs.map(&:mean_character_width)) || 0
-      @page_width  = (mediabox[2] - mediabox[0]).abs
-      @page_height = (mediabox[3] - mediabox[1]).abs
       @x_offset = @runs.map(&:x).sort.first || 0
       lowest_y = @runs.map(&:y).sort.first || 0
       @y_offset = lowest_y > 0 ? 0 : lowest_y
@@ -49,6 +48,14 @@ class PDF::Reader
 
     private
 
+    def page_width
+      (@mediabox[2].to_f - @mediabox[0].to_f).abs
+    end
+
+    def page_height
+      (@mediabox[3].to_f - @mediabox[1].to_f).abs
+    end
+
     # given an array of strings, return a new array with empty rows from the
     # beginning and end removed.
     #
@@ -67,19 +74,19 @@ class PDF::Reader
     end
 
     def row_count
-      @row_count ||= (@page_height / @mean_font_size).floor
+      @row_count ||= (page_height / @mean_font_size).floor
     end
 
     def col_count
-      @col_count ||= ((@page_width  / @median_glyph_width) * 1.05).floor
+      @col_count ||= ((page_width  / @median_glyph_width) * 1.05).floor
     end
 
     def row_multiplier
-      @row_multiplier ||= @page_height.to_f / row_count.to_f
+      @row_multiplier ||= page_height.to_f / row_count.to_f
     end
 
     def col_multiplier
-      @col_multiplier ||= @page_width.to_f / col_count.to_f
+      @col_multiplier ||= page_width.to_f / col_count.to_f
     end
 
     def mean(collection)

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -4,28 +4,28 @@ module PDF
     sig { returns(T.untyped) }
     attr_reader :objects
 
-    sig { params(input: T.untyped, opts: T.untyped).void }
+    sig { params(input: T.any(String, IO), opts: T::Hash[T.untyped, T.untyped]).void }
     def initialize(input, opts = {}); end
 
-    sig { returns(T.untyped) }
+    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
     def info; end
 
-    sig { returns(T.untyped) }
+    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
     def metadata; end
 
-    sig { returns(T.untyped) }
+    sig { returns(Integer) }
     def page_count; end
 
-    sig { returns(T.untyped) }
+    sig { returns(Float) }
     def pdf_version; end
 
-    sig { params(input: T.untyped, opts: T.untyped, block: T.untyped).returns(T.untyped) }
+    sig { params(input: T.any(String, IO), opts: T::Hash[T.untyped, T.untyped], block: T.proc.params(arg0: PDF::Reader).void).returns(T.untyped) }
     def self.open(input, opts = {}, &block); end
 
-    sig { returns(T.untyped) }
+    sig { returns(T::Array[PDF::Reader::Page]) }
     def pages; end
 
-    sig { params(num: T.untyped).returns(T.untyped) }
+    sig { params(num: Integer).returns(PDF::Reader::Page) }
     def page(num); end
 
     sig { params(obj: T.untyped).returns(T.untyped) }
@@ -34,13 +34,13 @@ module PDF
     sig { params(str: String).returns(T::Boolean)}
     def has_utf16_bom?(str); end
 
-    sig { params(obj: T.untyped).returns(T.untyped) }
+    sig { params(obj: String).returns(String) }
     def pdfdoc_to_utf8(obj); end
 
-    sig { params(obj: T.untyped).returns(T.untyped) }
+    sig { params(obj: String).returns(String) }
     def utf16_to_utf8(obj); end
 
-    sig { returns(T.untyped) }
+    sig { returns(T::Hash[Symbol, T.untyped]) }
     def root; end
 
     class Buffer
@@ -722,7 +722,7 @@ module PDF
     class Page
       include ResourceMethods
 
-      sig { returns(T.untyped) }
+      sig { returns(PDF::Reader::ObjectHash) }
       attr_reader :objects
 
       sig { returns(T.untyped) }
@@ -731,34 +731,34 @@ module PDF
       sig { returns(T.untyped) }
       attr_reader :cache
 
-      sig { params(objects: T.untyped, pagenum: T.untyped, options: T.untyped).void }
+      sig { params(objects: PDF::Reader::ObjectHash, pagenum: Integer, options: T::Hash[Symbol, T.untyped]).void }
       def initialize(objects, pagenum, options = {}); end
 
-      sig { returns(T.untyped) }
+      sig { returns(Integer) }
       def number; end
 
-      sig { returns(T.untyped) }
+      sig { returns(String) }
       def inspect; end
 
       sig { returns(T.untyped) }
       def attributes; end
 
-      sig { returns(T.untyped) }
+      sig { returns(String) }
       def orientation; end
 
-      sig { returns(T.untyped) }
+      sig { returns(String) }
       def text; end
 
-      sig { params(receivers: T.untyped).returns(T.untyped) }
+      sig { params(receivers: T.untyped).void }
       def walk(*receivers); end
 
-      sig { returns(T.untyped) }
+      sig { returns(String) }
       def raw_content; end
 
-      sig { returns(T.untyped) }
+      sig { returns(Integer) }
       def rotate; end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def boxes; end
 
       sig { returns(T.untyped) }
@@ -787,10 +787,10 @@ module PDF
       extend T::Sig
       DEFAULT_FONT_SIZE = 12
 
-      sig { params(runs: T.untyped, mediabox: T.untyped).void }
+      sig { params(runs: T::Array[PDF::Reader::TextRun], mediabox: T::Array[Numeric]).void }
       def initialize(runs, mediabox); end
 
-      sig { returns(T.untyped) }
+      sig { returns(String) }
       def to_s; end
 
       sig { params(rows: T.untyped).returns(T.untyped) }


### PR DESCRIPTION
`PDF::Reader`, `PDF::Reader::Page` and `PDF::Reader::PageLayout` are some of the first things a downstream user will interact with, let's define some types so they can confirm they're using the gem as intended by static type checking