### PR TITLE
restore sorbet check for dead code

### DIFF
--- a/auto/run-sorbet
+++ b/auto/run-sorbet
@@ -2,13 +2,4 @@
 #
 # Run the tests
 
-# Disable 7006 (https://sorbet.org/docs/error-reference#7006)
-# This error is sorbet warning about dead code. So far I've found this 
-# more harmful than helpful.
-#
-# A concrete example: I'm storing the type information in external rbi files, so the gem
-# doesn't pick up a runtime dependency on sorbet. However, that means I still need runtime
-# guard clauses in some methods to check the type or shape of an argument... but sorbet
-# considers these dead code. It thinks the type of the argument is guaranteed.
-
-$(dirname $0)/with-ruby srb tc --suppress-error-code 7006
+$(dirname $0)/with-ruby srb tc

--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -69,7 +69,7 @@ class PDF::Reader
     #
     #   [25, :A, :B]
     def differences=(diff)
-      raise ArgumentError, "diff must be an array" unless diff.kind_of?(Array)
+      PDF::Reader::Error.validate_type(diff, "diff", Array)
 
       @differences = {}
       byte = 0

--- a/lib/pdf/reader/error.rb
+++ b/lib/pdf/reader/error.rb
@@ -47,6 +47,13 @@ class PDF::Reader
       raise MalformedPDFError, "PDF malformed, expected '#{rvalue}' but found '#{lvalue}' instead" if lvalue != rvalue
     end
     ################################################################################
+    def self.validate_type(object, name, klass)
+      raise ArgumentError, "#{name} (#{object}) must be a #{klass}" unless object.is_a?(klass)
+    end
+    ################################################################################
+    def self.validate_not_nil(object, name)
+      raise ArgumentError, "#{object} must not be nil" if object.nil?
+    end
   end
 
   ################################################################################

--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -17,7 +17,7 @@ class PDF::Reader
     DEFAULT_FONT_SIZE = 12
 
     def initialize(runs, mediabox)
-      raise ArgumentError, "a mediabox must be provided" if mediabox.nil?
+      PDF::Reader::Error.validate_not_nil(mediabox, "mediabox")
 
       runs = ZeroWidthRunsFilter.exclude_zero_width_runs(runs)
       runs = OverlappingRunsFilter.exclude_redundant_runs(runs)

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -243,6 +243,12 @@ module PDF
 
       sig { params(lvalue: T.untyped, rvalue: T.untyped).returns(T.untyped) }
       def self.assert_equal(lvalue, rvalue); end
+
+      sig { params(object: Object, name: String, klass: Module).void }
+      def self.validate_type(object, name, klass); end
+
+      sig { params(object: Object, name: String).void }
+		  def self.validate_not_nil(object, name); end
     end
 
     class MalformedPDFError < RuntimeError


### PR DESCRIPTION
Originally disabled in PR #395, but I got some advice on how to re-enable it [on stackoverflow](https://stackoverflow.com/questions/70051079/how-should-i-manage-sorbet-errors-in-a-gem-where-type-info-must-be-in-rbi-files).

I'm not sure I even want this kind of check really, given how inconsistently they're used across the codebase. Maybe they have value, but only on the public API? Anyway, for now I'm focused on defining types in Sorbet rather than changing behaviour.