### PR TITLE
text run overlap filter should only remove runs with identical characters

### DIFF
--- a/lib/pdf/reader/overlapping_runs_filter.rb
+++ b/lib/pdf/reader/overlapping_runs_filter.rb
@@ -40,7 +40,8 @@ class PDF::Reader
 
     def self.detect_intersection(sweep_line_status, event_point)
       sweep_line_status.each do |open_text_run|
-        if event_point.x >= open_text_run.x &&
+        if open_text_run.text == event_point.run.text &&
+            event_point.x >= open_text_run.x &&
             event_point.x <= open_text_run.endx &&
             open_text_run.intersection_area_percent(event_point.run) >= OVERLAPPING_THRESHOLD
           return true

--- a/spec/overlapping_runs_filter_spec.rb
+++ b/spec/overlapping_runs_filter_spec.rb
@@ -45,6 +45,19 @@ describe PDF::Reader::OverlappingRunsFilter, "#exclude_redundant_runs" do
     end
   end
 
+  context "when there's two identically positioned runs with different text" do
+    let(:runs) do
+      [
+        PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello"),
+        PDF::Reader::TextRun.new(30, 700, 50, 12, "Bacon"),
+      ]
+    end
+
+    it "returns both of the runs" do
+      expect(result).to match_array(runs)
+    end
+  end
+
   context "when the second run overlaps the right edge of the first" do
     context "by 50%" do
       let(:runs) do


### PR DESCRIPTION
This was always the intention, and there's even a code comment to say it. But somehow that was never implemented?