### PR TITLE
Page#rectangles return the page boxes as PDF::Reader::Rectangle objects

### DIFF
--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -17,6 +17,8 @@ class PDF::Reader
     DEFAULT_FONT_SIZE = 12
 
     def initialize(runs, mediabox)
+      # mediabox is a 4-element array for now, but it'd be nice to switch to a
+      # PDF::Reader::Rectangle at some point
       PDF::Reader::Error.validate_not_nil(mediabox, "mediabox")
 
       runs = ZeroWidthRunsFilter.exclude_zero_width_runs(runs)
@@ -49,10 +51,12 @@ class PDF::Reader
     private
 
     def page_width
+      # TODO once @mediabox is a Rectangle, this can be just `@mediabox.width`
       (@mediabox[2].to_f - @mediabox[0].to_f).abs
     end
 
     def page_height
+      # TODO once @mediabox is a Rectangle, this can be just `@mediabox.height`
       (@mediabox[3].to_f - @mediabox[1].to_f).abs
     end
 

--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -45,14 +45,11 @@ module PDF
         @page = page
         @content = []
         @characters = []
-        @mediabox = page.objects.deref(page.attributes[:MediaBox])
-        device_bl = apply_rotation(*@state.ctm_transform(@mediabox[0], @mediabox[1]))
-        device_tr = apply_rotation(*@state.ctm_transform(@mediabox[2], @mediabox[3]))
-        @device_mediabox = [ device_bl.first, device_bl.last, device_tr.first, device_tr.last]
       end
 
       def content
-        PageLayout.new(@characters, @device_mediabox).to_s
+        mediabox = @page.rectangles[:MediaBox].to_a
+        PageLayout.new(@characters, mediabox).to_s
       end
 
       #####################################################

--- a/lib/pdf/reader/rectangle.rb
+++ b/lib/pdf/reader/rectangle.rb
@@ -23,6 +23,10 @@ module PDF
         @x1, @y1, @x2, @y2 = x1, y1, x2, y2
       end
 
+      def ==(other)
+        to_a == other.to_a
+      end
+
       def bottom_left
         [
           [@x1, @x2].min,
@@ -57,6 +61,16 @@ module PDF
 
       def width
         bottom_right[0] - bottom_left[0]
+      end
+
+      # A pdf-style 4-number array
+      def to_a
+        [
+          bottom_left[0],
+          bottom_left[1],
+          top_right[0],
+          top_right[1],
+        ]
       end
 
       def apply_rotation(degrees)

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -765,6 +765,9 @@ module PDF
       sig { returns(T::Hash[Symbol, T.untyped]) }
       def boxes; end
 
+      sig { returns(T::Hash[Symbol, PDF::Reader::Rectangle]) }
+      def rectangles; end
+
       sig { returns(T.untyped) }
       def root; end
 

--- a/spec/page_layout_spec.rb
+++ b/spec/page_layout_spec.rb
@@ -4,7 +4,7 @@
 describe PDF::Reader::PageLayout do
   describe "#to_s" do
     context "with an A4 page" do
-      let(:mediabox) { [0, 0, 595.28, 841.89 ]}
+      let(:mediabox) { [0, 0, 595.28, 841.89]}
 
       context "with no words" do
         subject { PDF::Reader::PageLayout.new([], mediabox)}

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -71,6 +71,45 @@ describe PDF::Reader::Page do
     end
   end
 
+  describe "#rectangles" do
+    let!(:page)    { browser.page(1) }
+    let!(:browser) { PDF::Reader.new(pdf_spec_file("all_page_boxes_exist")) }
+
+    it "returns a hash of all the different boxes" do
+      expect(page.attributes[:ArtBox]).to_not be_empty
+      expect(page.attributes[:BleedBox]).to_not be_empty
+      expect(page.attributes[:CropBox]).to_not be_empty
+      expect(page.attributes[:MediaBox]).to_not be_empty
+      expect(page.attributes[:TrimBox]).to_not be_empty
+
+      expect(page.rectangles).to eq(
+        {
+          ArtBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+          BleedBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+          CropBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+          MediaBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+          TrimBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+        }
+      )
+    end
+
+    context "mediabox and cropbox are references" do
+      let!(:browser) { PDF::Reader.new(pdf_spec_file("mediabox_and_cropbox_are_references")) }
+
+      it "returns a non-reference for the dimensions of the boxes" do
+        expect(page.rectangles).to eq(
+          {
+            ArtBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+            BleedBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+            CropBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+            MediaBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+            TrimBox: PDF::Reader::Rectangle.new(0, 0, 612, 792),
+          }
+        )
+      end
+    end
+  end
+
   describe "#walk" do
 
     context "with page 1 of cairo-basic.pdf" do


### PR DESCRIPTION
... with the page rotation (if any) applied.

These are soooo much nicer to work with than 4 element arrays.

Page#boxes is now implemented on top of Page#rectangles, so the page rotation is applied there as well. Page#boxes is soft deprecated and might be removed one day.