### PR TITLE
Fix glyph positioning in some rotation scenarios

### DIFF
--- a/lib/pdf/reader/page_state.rb
+++ b/lib/pdf/reader/page_state.rb
@@ -313,7 +313,7 @@ class PDF::Reader
       #                 may need to be added
       #
       def process_glyph_displacement(w0, tj, word_boundary)
-        fs = font_size # font size
+        fs = state[:text_font_size]
         tc = state[:char_spacing]
         if word_boundary
           tw = state[:word_spacing]
@@ -331,16 +331,16 @@ class PDF::Reader
           # apply horizontal scaling to spacing values but not font size
           tx = ((w0 * fs) + tc + tw) * th
         end
-
-        # TODO: I'm pretty sure that tx shouldn't need to be divided by
-        #       ctm[0] here, but this gets my tests green and I'm out of
-        #       ideas for now
         # TODO: support ty > 0
-        if ctm.a == 1 || ctm.a == 0
-          @text_matrix.horizontal_displacement_multiply!(tx)
-        else
-          @text_matrix.horizontal_displacement_multiply!(tx/ctm.a)
-        end
+        ty = 0
+        temp = TransformationMatrix.new(1, 0,
+                                        0, 1,
+                                        tx, ty)
+        @text_matrix = temp.multiply!(
+          @text_matrix.a, @text_matrix.b,
+          @text_matrix.c, @text_matrix.d,
+          @text_matrix.e, @text_matrix.f
+        )
         @font_size = @text_rendering_matrix = nil # invalidate cached value
       end
 

--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -119,6 +119,12 @@ module PDF
         end
       end
 
+      # TODO: revist this. It rotates the co-ordinates to the right direction, but I don't
+      #       think it sets the correct x,y values. We get away with it because we don't
+      #       return the text with co-ordinates, only the full text arranged in a string.
+      #
+      #       We should provide an API for extracting the text with positioning data and spec
+      #       that. I suspect the co-ords might be wrong for rotated pages
       def apply_rotation(x, y)
         if @page.rotate == 90
           tmp = x
@@ -126,10 +132,11 @@ module PDF
           y = tmp * -1
         elsif @page.rotate == 180
           y *= -1
+          x *= -1
         elsif @page.rotate == 270
-          tmp = x
-          x = y * -1
-          y = tmp * -1
+          tmp = y
+          y = x
+          x = tmp * -1
         end
         return x, y
       end

--- a/spec/column_spec.rb
+++ b/spec/column_spec.rb
@@ -19,8 +19,8 @@ describe PDF::Reader, "column specs" do
         page = reader.page(1)
         ft = page.text
         expect(ft).to match(/ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu/)
-        expect(ft).to match(/Lorem ipsum dolor sit amet, consectetur adipisic -\s+adipisicing elit, sed do eiusmod tempor incididunt/)
-        expect(ft).to match(/ing elit, sed do eiusmod tempor incididunt ut labore\s+ut labore et dolore magna aliqua. Ut enim ad minim/)
+        expect(ft).to match(/Lorem ipsum dolor sit amet, consectetur adipisic-\s+adipisicing elit, sed do eiusmod tempor incididunt/)
+        expect(ft).to match(/ingelit,seddoeiusmodtemporincididuntutlabore\s+utlaboreetdoloremagnaaliqua.Utenimadminim/)
         expect(ft).to match(/et dolore magna aliqua. Ut enim ad minim veniam,\s+veniam, quis nostrud exercitation ullamco laboris/)
         expect(ft).to match(/quis nostrud exercitation ullamco laboris nisi ut\s+nisi ut aliquip ex ea commodo consequat. Duis aute/)
         expect(ft).to match(/aliquip ex ea commodo consequat. Duis aute irure\s+irure dolor in reprehenderit in voluptate velit esse/)
@@ -36,7 +36,7 @@ describe PDF::Reader, "column specs" do
         # The following lines are in the second column, and their position with in the
         # string (from the left) should all be at the same spot
         match_pos_1 = find_position_of_match(ft, /adipisicing elit, sed do eiusmod tempor incididunt$/)
-        match_pos_2 = find_position_of_match(ft, /ut labore et dolore magna aliqua. Ut enim ad minim$/)
+        match_pos_2 = find_position_of_match(ft, /utlaboreetdoloremagnaaliqua.Utenimadminim$/)
         match_pos_3 = find_position_of_match(ft, /veniam, quis nostrud exercitation ullamco laboris$/)
         match_pos_4 = find_position_of_match(ft, /nisi ut aliquip ex ea commodo consequat. Duis aute$/)
         match_pos_5 = find_position_of_match(ft, /irure dolor in reprehenderit in voluptate velit esse$/)
@@ -60,7 +60,7 @@ describe PDF::Reader, "column specs" do
         # The following lines are in the first column of the page prior to the interruption
         col1_1   = find_position_of_match(ft, /^tate velit esse cillum dolore eu/)
         col1_2   = find_position_of_match(ft, /^fugiat nulla pariatur. Excepteur/)
-        col1_3   = find_position_of_match(ft, /^sint occaecat cupidatat non proi -/)
+        col1_3   = find_position_of_match(ft, /^sint occaecat cupidatat non proi-/)
         col1_4   = find_position_of_match(ft, /^dent, sunt in culpa qui officia de-/)
 
         expect(col1_1).not_to be_nil
@@ -78,8 +78,8 @@ describe PDF::Reader, "column specs" do
         # The following lines are in the second column of the page prior to the interruption
         col2_1   = find_position_of_match(ft, /occaecat cupidatat non proident,\s*anim/)
         col2_2   = find_position_of_match(ft, /sunt in culpa qui officia deserunt\s*sum/)
-        col2_3   = find_position_of_match(ft, /mollit anim id est laborum. Lo -\s*adipisicing/)
-        col2_4   = find_position_of_match(ft, /rem ipsum dolor sit amet, con -\s*tempor/)
+        col2_3   = find_position_of_match(ft, /mollit anim id est laborum. Lo-\s*adipisicing/)
+        col2_4   = find_position_of_match(ft, /rem ipsum dolor sit amet, con-\s*tempor/)
 
         expect(col2_1).not_to be_nil
         expect(col2_1).to eql(col2_2)
@@ -95,7 +95,7 @@ describe PDF::Reader, "column specs" do
         ft = reader.page(2).text
 
         # The following lines are in the third column of the page prior to the interruption
-        col3_a_1 = find_position_of_match(ft, /anim id est laborum. Lorem ip -$/)
+        col3_a_1 = find_position_of_match(ft, /anim id est laborum. Lorem ip-$/)
         col3_a_2 = find_position_of_match(ft, /sum dolor sit amet, consectetur$/)
         col3_a_3 = find_position_of_match(ft, /adipisicing elit, sed do eiusmod$/)
         col3_a_4 = find_position_of_match(ft, /tempor incididunt ut labore et$/)

--- a/spec/data/rotate-270-then-undo-inside-bt.pdf
+++ b/spec/data/rotate-270-then-undo-inside-bt.pdf
@@ -1,0 +1,84 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 205
+>>
+stream
+q
+BT
+2 Tr
+0 0 0 rg
+0 -1 1 0 534.5 320.2 Tm
+/F1.0 12 Tf
+[<>] TJ
+ET
+
+
+BT
+2 Tr
+0 0 0 rg
+0 -1 1 0 534.5 320.2 Tm
+/F1.0 12 Tf
+[<54686973207061676520697320726f74617465642032373020646567> 10 <72656573>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/Rotate 270
+/MediaBox [0 0 841.89 595.28]
+/CropBox [0 0 841.89 595.28]
+/BleedBox [0 0 841.89 595.28]
+/TrimBox [0 0 841.89 595.28]
+/ArtBox [0 0 841.89 595.28]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000471 00000 n 
+0000000779 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+876
+%%EOF

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -344,6 +344,9 @@ data/prince2.pdf:
 data/rotate-180.pdf:
   :bytes: 17738
   :md5: 5ab145b4527aabb75532d9b990f6df0c
+data/rotate-270-then-undo-inside-bt.pdf:
+  :bytes: 1091
+  :md5: 1a27af6fc501499dc89f728db0526240
 data/rotate-90-then-undo-with-br-text.pdf:
   :bytes: 1202
   :md5: d86bb1a0cb9b2fdde5bb43d3f7cd1e9a


### PR DESCRIPTION
Including some rotated pages, and some rotated text on non-rotated pages.

When processing glyph displacement after rendering a glyph, the spec is pretty clear that the calculation should be:

          [ 1  0  0 ]
    Tm =  [ 0  1  0 ]  x Tm
          [ tx ty 1 ]

However, for years pdf-reader has had it backwards:

               [ 1  0  0 ]
    Tm =  Tm x [ 0  1  0 ]
               [ tx ty 1 ]

We'd built up some compensating bugs to cover that for some PDFs too, like using a calculated font size instead of the raw font size from the page state. Also a divide by ctm.a that made no sense, and there was even a comment saying that.

Fixing the order of the matrix multiplication means those compensating bugs can also go away.

There are some minor changes to the text output of the columns spec, which I'm willing to wear. Mostly whitespace changes -  nothing significant - so I've updated the spec to match. I suspect these actually indicate some additional bugs in glyph displacement - particularly the way we process numeric arguments to the TJ (show_text_with_positioning) operator. I think this commit is an overall nett positive as it fixes some significant glyph positioning issues. We can iterate on the TJ operator handling separately.

Finally, there's a couple of tweaks to the apply_rotation in PageTextReceiver. This method is still buggy, and I've left a comment with some details. The current version will shift the characters around so they're positioned correctly relative to eachother, but the final x and y values are incorrect relative to the overall page boxes. I'll fix that up separately.

These changes were driven by a failing spec with a PDF based on the failure reported at #397. It's a page that's rotated by 270 degrees, and the rotation is undone in the BT block rather than via the CTM.

Fixes #376 
Fixes #316 
Fixes #271
Fixes #110 