### PR TITLE
Fix parsing of PDFs with stream objects that have an indirect objects…

### DIFF
--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -210,6 +210,9 @@ class PDF::Reader
       raise MalformedPDFError, "PDF malformed, missing stream length" unless dict.has_key?(:Length)
       if @objects
         length = @objects.deref(dict[:Length])
+        if dict[:Filter]
+          dict[:Filter] = @objects.deref(dict[:Filter])
+        end
       else
         length = dict[:Length] || 0
       end

--- a/spec/data/stream-with-indirect-filters.pdf
+++ b/spec/data/stream-with-indirect-filters.pdf
@@ -1,0 +1,73 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 7 0 R
+/Filter 8 0 R
+>>
+stream
+xœ5±Â0Dw…¿ $vrn¥ªlHÙ¢ÉÎÿ/ØT,ÖÙçw÷!:7RL‰­Ø¤sá¶Óéšı…Û ÇZfTIPt+¨1%™:"¾eìîbcM¼b˜¸Ìbê*¹oÁÇ¸¨¿û?XğÔà\w	¢ÅS¢C£Ñû¯cÛÜntiDwú|ò*È
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+7 0 obj
+140
+endobj
+8 0 obj
+[/FlateDecode]
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000422 00000 n 
+0000000688 00000 n 
+0000000785 00000 n 
+0000000804 00000 n 
+trailer
+<< /Size 9
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+834
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1514,4 +1514,16 @@ describe PDF::Reader, "integration specs" do
       end
     end
   end
+
+  context "Content stream with indirect object for filters array" do
+    let(:filename) { pdf_spec_file("stream-with-indirect-filters") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        expect(reader.page(1).text).to eql(
+          "The content stream for this page stores the filter in an indirect object"
+        )
+      end
+    end
+  end
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -377,6 +377,9 @@ data/standard_font_with_no_difference.pdf:
 data/stream-with-extra-byte.z:
   :bytes: 516
   :md5: cb7b8af4921811eb51d1d22a4194a6fe
+data/stream-with-indirect-filters.pdf:
+  :bytes: 1089
+  :md5: 1c3a3b5454d39a5ee6886ef3e81cc266
 data/surrogate_pair_integration_sample.pdf:
   :bytes: 1210387
   :md5: abc393e941d2aeb7a64f5e2ab1b58a92


### PR DESCRIPTION
… for a Filter

Like this:

    21 0 obj
    <<
    /Filter 22 0 R
    /Length 23 0 R
    >>
    stream
    x??[ݎ??^M?/???^W?W^R?g`P`&??E?^Mv?^E