### PR TITLE
Pass MediaBox to PageLayout as a Rectangle, not a 4-element Array

### DIFF
--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -23,7 +23,7 @@ class PDF::Reader
 
       runs = ZeroWidthRunsFilter.exclude_zero_width_runs(runs)
       runs = OverlappingRunsFilter.exclude_redundant_runs(runs)
-      @mediabox = mediabox
+      @mediabox = process_mediabox(mediabox)
       @runs = merge_runs(runs)
       @mean_font_size   = mean(@runs.map(&:font_size)) || DEFAULT_FONT_SIZE
       @mean_font_size = DEFAULT_FONT_SIZE if @mean_font_size == 0
@@ -51,13 +51,11 @@ class PDF::Reader
     private
 
     def page_width
-      # TODO once @mediabox is a Rectangle, this can be just `@mediabox.width`
-      (@mediabox[2].to_f - @mediabox[0].to_f).abs
+      @mediabox.width
     end
 
     def page_height
-      # TODO once @mediabox is a Rectangle, this can be just `@mediabox.height`
-      (@mediabox[3].to_f - @mediabox[1].to_f).abs
+      @mediabox.height
     end
 
     # given an array of strings, return a new array with empty rows from the
@@ -134,5 +132,17 @@ class PDF::Reader
     def local_string_insert(haystack, needle, index)
       haystack[Range.new(index, index + needle.length - 1)] = String.new(needle)
     end
+
+    def process_mediabox(mediabox)
+      if mediabox.is_a?(Array)
+        msg = "Passing the mediabox to PageLayout as an Array is deprecated," +
+          " please use a Rectangle instead"
+        $stderr.puts msg
+        PDF::Reader::Rectangle.from_array(mediabox)
+      else
+        mediabox
+      end
+    end
+
   end
 end

--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -48,7 +48,7 @@ module PDF
       end
 
       def content
-        mediabox = @page.rectangles[:MediaBox].to_a
+        mediabox = @page.rectangles[:MediaBox]
         PageLayout.new(@characters, mediabox).to_s
       end
 

--- a/lib/pdf/reader/rectangle.rb
+++ b/lib/pdf/reader/rectangle.rb
@@ -26,6 +26,19 @@ module PDF
         set_corners(x1, y1, x2, y2)
       end
 
+      def self.from_array(arr)
+        if arr.size != 4
+          raise ArgumentError, "Only 4-element Arrays can be converted to a Rectangle"
+        end
+
+        PDF::Reader::Rectangle.new(
+          arr[0].to_f,
+          arr[1].to_f,
+          arr[2].to_f,
+          arr[3].to_f,
+        )
+      end
+
       def ==(other)
         to_a == other.to_a
       end

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -794,7 +794,7 @@ module PDF
       extend T::Sig
       DEFAULT_FONT_SIZE = 12
 
-      sig { params(runs: T::Array[PDF::Reader::TextRun], mediabox: T::Array[Numeric]).void }
+      sig { params(runs: T::Array[PDF::Reader::TextRun], mediabox: T.any(T::Array[Numeric], PDF::Reader::Rectangle)).void }
       def initialize(runs, mediabox); end
 
       sig { returns(String) }
@@ -829,6 +829,9 @@ module PDF
 
       sig { params(haystack: T.untyped, needle: T.untyped, index: T.untyped).returns(T.untyped) }
       def local_string_insert(haystack, needle, index); end
+
+      sig { params(mediabox: T.untyped).returns(T.untyped) }
+      def process_mediabox(mediabox); end
     end
 
     class PageState
@@ -1122,6 +1125,9 @@ module PDF
     end
 
     class Rectangle
+      sig { params(arr: T::Array[Numeric]).returns(PDF::Reader::Rectangle) }
+      def self.from_array(arr); end
+
       sig do
         params(
           x1: Numeric,

--- a/spec/page_layout_spec.rb
+++ b/spec/page_layout_spec.rb
@@ -4,7 +4,7 @@
 describe PDF::Reader::PageLayout do
   describe "#to_s" do
     context "with an A4 page" do
-      let(:mediabox) { [0, 0, 595.28, 841.89]}
+      let(:mediabox) { PDF::Reader::Rectangle.new(0, 0, 595.28, 841.89)}
 
       context "with no words" do
         subject { PDF::Reader::PageLayout.new([], mediabox)}
@@ -201,9 +201,21 @@ describe PDF::Reader::PageLayout do
           expect(subject.to_s).to eq("bold")
         end
       end
+      context "with one word and the mediabox is provided as a 4-element array" do
+        let!(:runs) do
+          [
+            PDF::Reader::TextRun.new(30, 700, 50, 12, "Hello")
+          ]
+        end
+        subject { PDF::Reader::PageLayout.new(runs, mediabox.to_a)}
+
+        it "returns a correct string and prints a deprecation warning" do
+          expect(subject.to_s).to eq("Hello")
+        end
+      end
     end
     context "with a page that's too small to fit any of the text" do
-      let(:mediabox) { [0, 0, 46.560, 32.640]}
+      let(:mediabox) { PDF::Reader::Rectangle.new(0, 0, 46.560, 32.640)}
       let(:font_size) { 72 }
 
       it "returns an empty string" do
@@ -212,5 +224,6 @@ describe PDF::Reader::PageLayout do
         expect(layout.to_s).to eq("")
       end
     end
+
   end
 end


### PR DESCRIPTION
Rectangles are much easier to work with, and easier to type check. Some users of pdf-reader may be using PageLayout, so the Array param still works but we print a deprecation warning.