### PR TITLE
pipeline: move quality check to run before the rspec matrix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,12 @@ steps:
       DOCKER_IMAGE: "ruby"
       RUBY_VERSION: "2.7"
 
+  - command: "auto/run-quality"
+    label: "quality"
+    env:
+      DOCKER_IMAGE: "ruby"
+      RUBY_VERSION: "2.7"
+
   - wait
 
   - command: "auto/run-specs"

--- a/auto/run-quality
+++ b/auto/run-quality
@@ -1,0 +1,5 @@
+#! /bin/bash -eu
+#
+# Run the tests
+
+$(dirname $0)/with-ruby rake quality

--- a/auto/run-specs
+++ b/auto/run-specs
@@ -2,4 +2,4 @@
 #
 # Run the tests
 
-$(dirname $0)/with-ruby rake
+$(dirname $0)/with-ruby rspec


### PR DESCRIPTION
If the quality checks are going to fail, we may as well fail the build early and not run the specs on 7+ rubies