### PR TITLE
Add PDF::Reader::Page#runs method, to extract text from a page with positioning info

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ desc "Run cane to check quality metrics"
 Cane::RakeTask.new(:quality) do |cane|
   cane.abc_max = 20
   cane.style_measure = 100
-  cane.max_violations = 32
+  cane.max_violations = 28
 
   cane.use Morecane::EncodingCheck, :encoding_glob => "{app,lib,spec}/**/*.rb"
 end

--- a/lib/pdf/reader/page.rb
+++ b/lib/pdf/reader/page.rb
@@ -101,12 +101,23 @@ module PDF
       # returns the plain text content of this page encoded as UTF-8. Any
       # characters that can't be translated will be returned as a ▯
       #
-      def text
+      def text(opts = {})
         receiver = PageTextReceiver.new
         walk(receiver)
-        receiver.content
+        runs = receiver.runs(opts)
+
+        # rectangles[:MediaBox] can never be nil, but I have no easy way to tell sorbet that atm
+        mediabox = rectangles[:MediaBox] || Rectangle.new(0, 0, 0, 0)
+
+        PageLayout.new(runs, mediabox).to_s
       end
       alias :to_s :text
+
+      def runs(opts = {})
+        receiver = PageTextReceiver.new
+        walk(receiver)
+        receiver.runs(opts)
+      end
 
       # processes the raw content stream for this page in sequential order and
       # passes callbacks to the receiver objects.

--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -22,10 +22,7 @@ class PDF::Reader
       PDF::Reader::Error.validate_not_nil(mediabox, "mediabox")
 
       @mediabox = process_mediabox(mediabox)
-      runs = ZeroWidthRunsFilter.exclude_zero_width_runs(runs)
-      runs = OverlappingRunsFilter.exclude_redundant_runs(runs)
-      runs = BoundingRectangleRunsFilter.runs_within_rect(runs, @mediabox)
-      @runs = merge_runs(runs)
+      @runs = runs
       @mean_font_size   = mean(@runs.map(&:font_size)) || DEFAULT_FONT_SIZE
       @mean_font_size = DEFAULT_FONT_SIZE if @mean_font_size == 0
       @median_glyph_width = median(@runs.map(&:mean_character_width)) || 0
@@ -105,28 +102,6 @@ class PDF::Reader
         0
       else
         collection.sort[(collection.size * 0.5).floor]
-      end
-    end
-
-    # take a collection of TextRun objects and merge any that are in close
-    # proximity
-    def merge_runs(runs)
-      runs.group_by { |char|
-        char.y.to_i
-      }.map { |y, chars|
-        group_chars_into_runs(chars.sort)
-      }.flatten.sort
-    end
-
-    def group_chars_into_runs(chars)
-      chars.each_with_object([]) do |char, runs|
-        if runs.empty?
-          runs << char
-        elsif runs.last.mergable?(char)
-          runs[-1] = runs.last + char
-        else
-          runs << char
-        end
       end
     end
 

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -757,8 +757,11 @@ module PDF
       sig { returns(T::Array[Numeric]) }
       def origin; end
 
-      sig { returns(String) }
-      def text; end
+      sig { params(opts: T::Hash[Symbol, T.untyped]).returns(T::Array[PDF::Reader::TextRun]) }
+      def runs(opts = {}); end
+
+      sig { params(opts: T::Hash[Symbol, T.untyped]).returns(String) }
+      def text(opts = {}); end
 
       sig { params(receivers: T.untyped).void }
       def walk(*receivers); end
@@ -1005,6 +1008,9 @@ module PDF
 
       sig { params(str: T.untyped).returns(T.untyped) }
       def move_to_next_line_and_show_text(str); end
+
+      sig { params(opts: T::Hash[Symbol, T.untyped]).returns(T::Array[PDF::Reader::TextRun]) }
+      def runs(opts = {}); end
 
       sig { params(aw: T.untyped, ac: T.untyped, string: T.untyped).returns(T.untyped) }
       def set_spacing_next_line_show_text(aw, ac, string); end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,17 @@
+# typed: false
+# coding: utf-8
+
+# A custom matcher for confirming a Point is close to another point. This is helpful
+# because the x and y co-ordinates of a point are floats so we can't match on them exactly
+RSpec::Matchers.define :be_close_to do |close_to_point|
+  match do |actual_point|
+    (actual_point.x >= close_to_point.x - 0.01) &&
+      (actual_point.x <= close_to_point.x + 0.01) &&
+      (actual_point.y >= close_to_point.y - 0.01) &&
+      (actual_point.y <= close_to_point.y + 0.01)
+  end
+  failure_message do |actual_point|
+    "expected that (#{actual_point.x},#{actual_point.y}) would be within" +
+      " 0.01 of (#{close_to_point.x},#{close_to_point.y})"
+  end
+end


### PR DESCRIPTION
We've had PDF::Reader::Page#text for years. It returns a plain text representation of the page, with the text layed out and positioned. It works reasonably well, but the positioning algorithim has bugs and we get occasional reports where it hasn't worked too well.
    
Page#runs is an escape hatch. User can request the character info for the page as an Array of PDF::Reader::TextRun objects. Each TextRun has one or more characters, the x,y co-ordinates of the origin (bottom left corner), the width, and the font size. Users can use this data in any way they need, possibly including building a custom layout algorithm.
    
Use it like this:

```ruby
PDF::Reader.open("somefile.pdf") do |pdf|
  reader.page(1).runs.each do |run|
    puts "#{run.text} (#{run.x},#{run.y}) width: #{run.width} font_size: #{run.font_size}"
  end
end
```

The runs method supports some options:
    
* rect - A PDF::Reader::Rectangle - filter out any characters that aren't inside this rectangle. Defaults to the page MediaBox
* skip_zero_width - skip text that renders with a width of 0. Defaults to true
* skip_overlapping - skip duplicate text that render on top of the same text. Defaults to true
* merge - merge characters that render in sequence. Defaults to true. If this is false, the result will be an Array of single characer TextRun's.
    
For example, here's extracting the runs for page 1 without merging:

```ruby
PDF::Reader.open("somefile.pdf") do |pdf|
  reader.page(1).runs(merge: false).each do |run|
    puts run.inspect
  end
end
```

A side effect of this change is that Page#text also accepts the above options. This might be useful for folks who want to extract text from a part of the page without implementing their own algorithm. That would look something like this:

```ruby
PDF::Reader.open("somefile.pdf") do |pdf|
  puts reader.page(1).text(rect: PDF::Reader::Rectangle.new(0, 0, 100, 100))
end
```