### PR TITLE
Avoid providing a initial value for instance var type hints in RBI file

### DIFF
--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -1111,8 +1111,8 @@ module PDF
         ).void
       end
       def initialize(x, y)
-        @x = T.let(0, Numeric)
-        @y = T.let(0, Numeric)
+        @x = T.let(T.unsafe(nil), Numeric)
+        @y = T.let(T.unsafe(nil), Numeric)
       end
 
       sig { returns(Numeric) }
@@ -1155,10 +1155,10 @@ module PDF
       end
 
       def initialize(x1, y1, x2, y2)
-        @bottom_left = T.let(PDF::Reader::Point.new(0,0), PDF::Reader::Point)
-        @bottom_right = T.let(PDF::Reader::Point.new(0,0), PDF::Reader::Point)
-        @top_left = T.let(PDF::Reader::Point.new(0,0), PDF::Reader::Point)
-        @top_right = T.let(PDF::Reader::Point.new(0,0), PDF::Reader::Point)
+        @bottom_left = T.let(T.unsafe(nil), PDF::Reader::Point)
+        @bottom_right = T.let(T.unsafe(nil), PDF::Reader::Point)
+        @top_left = T.let(T.unsafe(nil), PDF::Reader::Point)
+        @top_right = T.let(T.unsafe(nil), PDF::Reader::Point)
       end
 
       sig { returns(PDF::Reader::Point) }


### PR DESCRIPTION
These type hints were added in #415 while changing some files to `typed: strict`. It felt weird providing an initial value that I knew wasn't used, and in a follow up comment on the PR it was suggested that I can use this form to be clear that I'm annotating the ivar type without setting a value.

`T.unsafe(nil)` also feels a bit weird. So much syntax for so little value. It'd be nice if sorbet had a way to only specify the ivar type in an RBI files, without the value argument at all 🤷‍♂️