### PR TITLE
Add build step that requires new files to use 'typed: strict'

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,12 @@ steps:
       DOCKER_IMAGE: "ruby"
       RUBY_VERSION: "2.7"
 
+  - command: "auto/run-require-strict-typing"
+    label: "typed: strict"
+    env:
+      DOCKER_IMAGE: "ruby"
+      RUBY_VERSION: "2.7"
+
   - command: "auto/run-quality"
     label: "quality"
     env:

--- a/auto/run-require-strict-typing
+++ b/auto/run-require-strict-typing
@@ -1,0 +1,5 @@
+#! /bin/bash -eu
+#
+# Confirm recent ruby files use strict typing
+
+$(dirname $0)/with-ruby ./scripts/require-strict-typing 

--- a/scripts/require-strict-typing
+++ b/scripts/require-strict-typing
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+sha_that_introduced_sorbet = 'feb9203'
+
+raw_files_added = `git diff --numstat --diff-filter=A #{sha_that_introduced_sorbet} HEAD -- lib/`
+
+just_files_added = raw_files_added.split("\n").map { |line|
+  line.split(/\s+/).last
+}
+
+files_added_without_strict_typing = just_files_added.reject { |path|
+  File.read(path).include?("typed: strict")
+}
+
+if files_added_without_strict_typing.any?
+  $stderr.puts "The following source files added since #{sha_that_introduced_sorbet} need 'typed: strict' added:'"
+  files_added_without_strict_typing.each do |path|
+    $stderr.puts "- #{path}"
+  end
+  exit 1
+else
+  puts "All source files added since #{sha_that_introduced_sorbet} have strict typing"
+end


### PR DESCRIPTION
Let's see if ratcheting the strict typing slowly helps the maintainability of the project.