### PR TITLE
Implement decryption for files using revision 6 of the encryption spec

### DIFF
--- a/lib/pdf/reader/key_builder_v5.rb
+++ b/lib/pdf/reader/key_builder_v5.rb
@@ -39,10 +39,12 @@ class PDF::Reader
     # and exception will be raised.
     #
     def key(pass)
-      pass = pass.byteslice(0...127)   # UTF-8 encoded password. first 127 bytes
+      pass = pass.byteslice(0...127).to_s   # UTF-8 encoded password. first 127 bytes
 
       encrypt_key   = auth_owner_pass(pass)
       encrypt_key ||= auth_user_pass(pass)
+      encrypt_key ||= auth_owner_pass_r6(pass)
+      encrypt_key ||= auth_user_pass_r6(pass)
 
       raise PDF::Reader::EncryptedPDFError, "Invalid password (#{pass})" if encrypt_key.nil?
       encrypt_key
@@ -77,6 +79,60 @@ class PDF::Reader
         cipher.update(@user_encryption_key) + cipher.final
       end
     end
+
+    def auth_owner_pass_r6(password)
+      if r6_digest(password, @owner_key[32..39].to_s, @user_key[0,48].to_s) == @owner_key[0..31]
+        cipher = OpenSSL::Cipher.new('AES-256-CBC')
+        cipher.decrypt
+        cipher.key = r6_digest(password, @owner_key[40,8].to_s, @user_key[0, 48].to_s)
+        cipher.iv = "\x00" * 16
+        cipher.padding = 0
+        cipher.update(@owner_encryption_key) + cipher.final
+      end
+    end
+
+    def auth_user_pass_r6(password)
+      if r6_digest(password, @user_key[32..39].to_s) == @user_key[0..31]
+        cipher = OpenSSL::Cipher.new('AES-256-CBC')
+        cipher.decrypt
+        cipher.key = r6_digest(password, @user_key[40,8].to_s)
+        cipher.iv = "\x00" * 16
+        cipher.padding = 0
+        cipher.update(@user_encryption_key) + cipher.final
+      end
+    end
+
+    # PDF 2.0 spec, 7.6.4.3.4
+    # Algorithm 2.B: Computing a hash (revision 6 and later)
+    def r6_digest(password, salt, user_key = '')
+      k = Digest::SHA256.digest(password + salt + user_key)
+      e = ''
+
+      i = 0
+      while i < 64 or e.getbyte(-1).to_i > i - 32
+        k1 = (password + k + user_key) * 64
+
+        aes = OpenSSL::Cipher.new("aes-128-cbc").encrypt
+        aes.key = k[0, 16].to_s
+        aes.iv = k[16, 16].to_s
+        aes.padding = 0
+        e = String.new(aes.update(k1))
+        k = case unpack_128bit_bigendian_int(e) % 3
+            when 0 then Digest::SHA256.digest(e)
+            when 1 then Digest::SHA384.digest(e)
+            when 2 then Digest::SHA512.digest(e)
+            end
+        i = i + 1
+      end
+
+      k[0, 32].to_s
+    end
+
+    def unpack_128bit_bigendian_int(str)
+      ints = str[0,16].to_s.unpack("N*")
+      (ints[0].to_i << 96) + (ints[1].to_i << 64) + (ints[2].to_i << 32) + ints[3].to_i
+    end
+
   end
 end
 

--- a/lib/pdf/reader/security_handler_factory.rb
+++ b/lib/pdf/reader/security_handler_factory.rb
@@ -62,7 +62,9 @@ class PDF::Reader
         (version <= 3 || (version == 4 && ((algorithm == :V2) || (algorithm == :AESV2))))
     end
 
-    # This handler supports AES-256 encryption defined in PDF 1.7 Extension Level 3
+    # This handler supports both
+    # - AES-256 encryption defined in PDF 1.7 Extension Level 3 ('revision 5')
+    # - AES-256 encryption defined in PDF 2.0 ('revision 6')
     def self.standard_v5?(encrypt)
       return false if encrypt.nil?
 
@@ -71,9 +73,7 @@ class PDF::Reader
       revision = encrypt.fetch(:R, 0)
       algorithm = encrypt.fetch(:CF, {}).fetch(encrypt[:StmF], {}).fetch(:CFM, nil)
       (filter == :Standard) && (encrypt[:StmF] == encrypt[:StrF]) &&
-          ((version == 5) && (revision == 5) && (algorithm == :AESV3))
+          ((version == 5) && (revision == 5 || revision == 6) && (algorithm == :AESV3))
     end
-
-
   end
 end

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -488,6 +488,18 @@ module PDF
 
       sig { params(password: T.untyped).returns(T.untyped) }
       def auth_user_pass(password); end
+
+      sig { params(password: String).returns(T.nilable(String)) }
+      def auth_owner_pass_r6(password); end
+
+      sig { params(password: String).returns(T.nilable(String)) }
+      def auth_user_pass_r6(password); end
+
+      sig { params(password: String, salt: String, user_key: String).returns(String)}
+      def r6_digest(password, salt, user_key = ''); end
+
+      sig { params(str: String).returns(Integer)}
+      def unpack_128bit_bigendian_int(str); end
     end
 
     class LZW

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -827,22 +827,45 @@ describe PDF::Reader, "integration specs" do
     context "with the user pass" do
       let(:pass) { "apples" }
 
-      # TODO: remove this spec
-      it "raises UnsupportedFeatureError" do
-        expect {
-          PDF::Reader.open(filename, :password => pass) do |reader|
-            reader.page(1).text
-          end
-        }.to raise_error(PDF::Reader::EncryptedPDFError)
+      it "correctly extracts text" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.page(1).text).to start_with(
+            "This sample file is encrypted with a user password"
+          )
+        end
       end
-
-      it "correctly extracts text"
-      it "correctly extracts info"
+      it "correctly extracts info" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.info).to eq(
+            :Creator=>"Writer",
+            :Producer=>"LibreOffice 3.3",
+            :CreationDate=>"D:20110814231057+10'00'",
+            :ModDate=>"D:20170115224358+11'00'"
+          )
+        end
+      end
     end
 
     context "with the owner pass" do
-      it "correctly extracts text"
-      it "correctly extracts info"
+      let(:pass) { "password" }
+
+      it "correctly extracts text" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.page(1).text).to start_with(
+            "This sample file is encrypted with a user password"
+          )
+        end
+      end
+      it "correctly extracts info" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.info).to eq(
+            :Creator=>"Writer",
+            :Producer=>"LibreOffice 3.3",
+            :CreationDate=>"D:20110814231057+10'00'",
+            :ModDate=>"D:20170115224358+11'00'"
+          )
+        end
+      end
     end
   end
 
@@ -854,22 +877,46 @@ describe PDF::Reader, "integration specs" do
     context "with the user pass" do
       let(:pass) { "apples" }
 
-      # TODO: remove this spec
-      it "raises UnsupportedFeatureError" do
-        expect {
-          PDF::Reader.open(filename, :password => pass) do |reader|
-            reader.page(1).text
-          end
-        }.to raise_error(PDF::Reader::EncryptedPDFError)
+      it "correctly extracts text" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.page(1).text).to start_with(
+            "This sample file is encrypted with a user password"
+          )
+        end
       end
 
-      it "correctly extracts text"
-      it "correctly extracts info"
+      it "correctly extracts info" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.info).to eq(
+            :Creator=>"Writer",
+            :Producer=>"LibreOffice 3.3",
+            :CreationDate=>"D:20110814231057+10'00'",
+            :ModDate=>"D:20170115224526+11'00'"
+          )
+        end
+      end
     end
 
     context "with the owner pass" do
-      it "correctly extracts text"
-      it "correctly extracts info"
+      let(:pass) { "password" }
+
+      it "correctly extracts text" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.page(1).text).to start_with(
+            "This sample file is encrypted with a user password"
+          )
+        end
+      end
+      it "correctly extracts info" do
+        PDF::Reader.open(filename, :password => pass) do |reader|
+          expect(reader.info).to eq(
+            :Creator=>"Writer",
+            :Producer=>"LibreOffice 3.3",
+            :CreationDate=>"D:20110814231057+10'00'",
+            :ModDate=>"D:20170115224526+11'00'"
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The PDF 2.0 spec adds a new way of calculating the encryption key for AES encrypted files, identified as 'revision 6'.

We've had pending specs for years with revision 6 encrypted PDFs, and this finally adds support for reading them