### PR TITLE
Add integration specs for text extraction with Boxes

### DIFF
--- a/lib/pdf/reader/page.rb
+++ b/lib/pdf/reader/page.rb
@@ -186,7 +186,7 @@ module PDF
       #
       def rectangles
         mediabox = objects.deref!(attributes[:MediaBox])
-        cropbox = objects.deref!(attributes[:Cropbox]) || mediabox
+        cropbox = objects.deref!(attributes[:CropBox]) || mediabox
         bleedbox = objects.deref!(attributes[:BleedBox]) || cropbox
         trimbox = objects.deref!(attributes[:TrimBox]) || cropbox
         artbox = objects.deref!(attributes[:ArtBox]) || cropbox

--- a/spec/data/text_outside_cropbox_and_mediabox.pdf
+++ b/spec/data/text_outside_cropbox_and_mediabox.pdf
@@ -1,0 +1,101 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 539
+>>
+stream
+q
+
+BT
+136.0 527.384 Td
+/F1.0 12 Tf
+[<54686973207465> 30 <787420697320696e73696465207468652043726f70426f> 30 <78>] TJ
+ET
+
+
+BT
+136.0 497.384 Td
+/F1.0 12 Tf
+[<5468657265206973206164646974696f6e616c207465> 30 <7874206f757473696465>] TJ
+ET
+
+
+BT
+136.0 467.384 Td
+/F1.0 12 Tf
+[<7468652043726f70426f> 30 <7820616e64204d65646961426f> 30 <78>] TJ
+ET
+
+
+BT
+41.0 41.0 Td
+/F1.0 12 Tf
+[<42657477> 10 <65656e2043726f70426f> 30 <7820616e64204d65646961426f> 30 <78>] TJ
+ET
+
+
+BT
+736.0 836.0 Td
+/F1.0 12 Tf
+[<4f757473696465204d65646961426f> 30 <78>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [100 100 412 592]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000805 00000 n 
+0000001075 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+1172
+%%EOF

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -386,6 +386,9 @@ data/surrogate_pair_integration_sample.pdf:
 data/symbol.pdf:
   :bytes: 1055
   :md5: 57941286e6442f5c0b295611a99e0f56
+data/text_outside_cropbox_and_mediabox.pdf:
+  :bytes: 1388
+  :md5: 853edffb3c14d2e223e6f895e503097c
 data/textwrapcr.pdf:
   :bytes: 739
   :md5: 9700990dd8adb5d2bb83fc5f4af5c2ae


### PR DESCRIPTION
The sample file was built like this (and with a mod to the prawn source to specify a CropBox):

```ruby
    Prawn::Document.generate("hello.pdf") do
      text_box "This text is inside the CropBox", at: [100, 500]
      text_box "There is additional text outside", at: [100, 470]
      text_box "the CropBox and MediaBox", at: [100, 440]
      draw_text "Between CropBox and MediaBox", at: [5, 5]
      draw_text "Outside MediaBox", at: [700, 800]
    end
```

This also flushed out a bug in Page#rectangles - we weren't returning the CropBox correctly