### PR TITLE
add RBI sigs for PDF::Reader::Parser

### DIFF
--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -103,7 +103,7 @@ class PDF::Reader
       obj = parse_token
       post_obj = parse_token
 
-      if post_obj == "stream"
+      if obj.is_a?(Hash) && post_obj == "stream"
         stream(obj)
       else
         obj

--- a/lib/pdf/reader/xref.rb
+++ b/lib/pdf/reader/xref.rb
@@ -143,7 +143,7 @@ class PDF::Reader
         params << buf.token
       end
 
-      trailer = Parser.new(buf, self).parse_token
+      trailer = Parser.new(buf).parse_token
 
       unless trailer.kind_of?(Hash)
         raise MalformedPDFError, "PDF malformed, trailer should be a dictionary"

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -1141,6 +1141,48 @@ module PDF
     }
     end
 
+    class Parser
+      sig { params(buffer: PDF::Reader::Buffer, objects: T.nilable(PDF::Reader::ObjectHash)).void }
+      def initialize(buffer, objects=nil); end
+
+      sig {
+        params(
+          operators: T::Hash[T.any(String, PDF::Reader::Token), Symbol]
+        ).returns(
+          T.any(PDF::Reader::Reference, PDF::Reader::Token, Numeric, String, Symbol, T::Array[T.untyped], T::Hash[T.untyped, T.untyped], NilClass)
+        )
+      }
+      def parse_token(operators={}); end
+
+      sig {
+        params(
+         id: Integer,
+         gen: Integer
+        ).returns(
+          T.any(PDF::Reader::Reference, PDF::Reader::Token, PDF::Reader::Stream, Numeric, String, Symbol, T::Array[T.untyped], T::Hash[T.untyped, T.untyped], NilClass)
+        )
+      }
+      def object(id, gen); end
+
+      sig { returns(T::Hash[T.untyped, T.untyped]) }
+      def dictionary; end
+
+      sig { returns(Symbol) }
+      def pdf_name; end
+
+      sig { returns(T::Array[T.untyped]) }
+      def array; end
+
+      sig { returns(String) }
+      def hex_string; end
+
+      sig { returns(String) }
+      def string; end
+
+      sig { params(dict: T::Hash[T.untyped, T.untyped]).returns(PDF::Reader::Stream) }
+      def stream(dict); end
+    end
+
     class Point
       sig do
         params(


### PR DESCRIPTION
`PDF::Reader::Parser` missed out on RBI signatures in #361 because parlour wasn't able to generate them.

Now I'm more comfortable with the syntax, I can just hand craft them.