### PR TITLE
Convert ResourceMethods to a class that we delegate to

### DIFF
--- a/lib/pdf/reader.rb
+++ b/lib/pdf/reader.rb
@@ -283,7 +283,7 @@ module PDF
 end
 ################################################################################
 
-require 'pdf/reader/resource_methods'
+require 'pdf/reader/resources'
 require 'pdf/reader/buffer'
 require 'pdf/reader/bounding_rectangle_runs_filter'
 require 'pdf/reader/cid_widths'

--- a/lib/pdf/reader/error.rb
+++ b/lib/pdf/reader/error.rb
@@ -51,6 +51,10 @@ class PDF::Reader
       raise ArgumentError, "#{name} (#{object}) must be a #{klass}" unless object.is_a?(klass)
     end
     ################################################################################
+    def self.validate_type_as_malformed(object, name, klass)
+      raise MalformedPDFError, "#{name} (#{object}) must be a #{klass}" unless object.is_a?(klass)
+    end
+    ################################################################################
     def self.validate_not_nil(object, name)
       raise ArgumentError, "#{object} must not be nil" if object.nil?
     end

--- a/lib/pdf/reader/form_xobject.rb
+++ b/lib/pdf/reader/form_xobject.rb
@@ -15,7 +15,6 @@ module PDF
     # This behaves and looks much like a limited PDF::Reader::Page class.
     #
     class FormXObject
-      include ResourceMethods
 
       attr_reader :xobject
 
@@ -34,7 +33,7 @@ module PDF
       # to most available metrics for each font.
       #
       def font_objects
-        raw_fonts = @objects.deref(resources[:Font] || {})
+        raw_fonts = @objects.deref(fonts)
         ::Hash[raw_fonts.map { |label, font|
           [label, PDF::Reader::Font.new(@objects, @objects.deref(font))]
         }]
@@ -56,12 +55,44 @@ module PDF
         @xobject.unfiltered_data
       end
 
+      def color_spaces
+        resources.color_spaces
+      end
+
+      def fonts
+        resources.fonts
+      end
+
+      def graphic_states
+        resources.graphic_states
+      end
+
+      def patterns
+        resources.patterns
+      end
+
+      def procedure_sets
+        resources.procedure_sets
+      end
+
+      def properties
+        resources.properties
+      end
+
+      def shadings
+        resources.shadings
+      end
+
+      def xobjects
+        resources.xobjects
+      end
+
       private
 
       # Returns the resources that accompany this form.
       #
       def resources
-        @resources ||= @objects.deref(@xobject.hash[:Resources]) || {}
+        @resources ||= Resources.new(@objects, @objects.deref(@xobject.hash[:Resources]) || {})
       end
 
       def callback(receivers, name, params=[])

--- a/lib/pdf/reader/form_xobject.rb
+++ b/lib/pdf/reader/form_xobject.rb
@@ -15,8 +15,18 @@ module PDF
     # This behaves and looks much like a limited PDF::Reader::Page class.
     #
     class FormXObject
+      extend Forwardable
 
       attr_reader :xobject
+
+      def_delegators :resources, :color_spaces
+      def_delegators :resources, :fonts
+      def_delegators :resources, :graphic_states
+      def_delegators :resources, :patterns
+      def_delegators :resources, :procedure_sets
+      def_delegators :resources, :properties
+      def_delegators :resources, :shadings
+      def_delegators :resources, :xobjects
 
       def initialize(page, xobject, options = {})
         @page    = page
@@ -53,38 +63,6 @@ module PDF
       #
       def raw_content
         @xobject.unfiltered_data
-      end
-
-      def color_spaces
-        resources.color_spaces
-      end
-
-      def fonts
-        resources.fonts
-      end
-
-      def graphic_states
-        resources.graphic_states
-      end
-
-      def patterns
-        resources.patterns
-      end
-
-      def procedure_sets
-        resources.procedure_sets
-      end
-
-      def properties
-        resources.properties
-      end
-
-      def shadings
-        resources.shadings
-      end
-
-      def xobjects
-        resources.xobjects
       end
 
       private

--- a/lib/pdf/reader/page.rb
+++ b/lib/pdf/reader/page.rb
@@ -14,6 +14,7 @@ module PDF
     # objects accessor to help walk the page dictionary in any useful way.
     #
     class Page
+      extend Forwardable
 
       # lowlevel hash-like access to all objects in the underlying PDF
       attr_reader :objects
@@ -25,6 +26,15 @@ module PDF
       # the current document and is used to avoid repeating expensive
       # operations
       attr_reader :cache
+
+      def_delegators :resources, :color_spaces
+      def_delegators :resources, :fonts
+      def_delegators :resources, :graphic_states
+      def_delegators :resources, :patterns
+      def_delegators :resources, :procedure_sets
+      def_delegators :resources, :properties
+      def_delegators :resources, :shadings
+      def_delegators :resources, :xobjects
 
       # creates a new page wrapper.
       #
@@ -211,38 +221,6 @@ module PDF
           TrimBox: trimrect,
           ArtBox: artrect,
         }
-      end
-
-      def color_spaces
-        resources.color_spaces
-      end
-
-      def fonts
-        resources.fonts
-      end
-
-      def graphic_states
-        resources.graphic_states
-      end
-
-      def patterns
-        resources.patterns
-      end
-
-      def procedure_sets
-        resources.procedure_sets
-      end
-
-      def properties
-        resources.properties
-      end
-
-      def shadings
-        resources.shadings
-      end
-
-      def xobjects
-        resources.xobjects
       end
 
       private

--- a/lib/pdf/reader/page.rb
+++ b/lib/pdf/reader/page.rb
@@ -14,7 +14,6 @@ module PDF
     # objects accessor to help walk the page dictionary in any useful way.
     #
     class Page
-      include ResourceMethods
 
       # lowlevel hash-like access to all objects in the underlying PDF
       attr_reader :objects
@@ -214,6 +213,38 @@ module PDF
         }
       end
 
+      def color_spaces
+        resources.color_spaces
+      end
+
+      def fonts
+        resources.fonts
+      end
+
+      def graphic_states
+        resources.graphic_states
+      end
+
+      def patterns
+        resources.patterns
+      end
+
+      def procedure_sets
+        resources.procedure_sets
+      end
+
+      def properties
+        resources.properties
+      end
+
+      def shadings
+        resources.shadings
+      end
+
+      def xobjects
+        resources.xobjects
+      end
+
       private
 
       def root
@@ -224,7 +255,7 @@ module PDF
       # resources inherited from parents.
       #
       def resources
-        @resources ||= @objects.deref(attributes[:Resources]) || {}
+        @resources ||= Resources.new(@objects, @objects.deref(attributes[:Resources]) || {})
       end
 
       def content_stream(receivers, instructions)

--- a/lib/pdf/reader/resources.rb
+++ b/lib/pdf/reader/resources.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # Setting this file to "typed: true" is difficult because it's a mixin that assumes some things
@@ -10,7 +10,12 @@ module PDF
 
     # mixin for common methods in Page and FormXobjects
     #
-    module ResourceMethods
+    class Resources
+
+      def initialize(objects, resources)
+        @objects = objects
+        @resources = resources
+      end
 
       # Returns a Hash of color spaces that are available to this page
       #
@@ -19,7 +24,9 @@ module PDF
       #       of calling it over and over.
       #
       def color_spaces
-        @objects.deref!(resources[:ColorSpace]) || {}
+        (@objects.deref!(@resources[:ColorSpace]) || {}).tap { |obj|
+          PDF::Reader::Error.validate_type_as_malformed(obj, "ColorSpace dictionary", Hash)
+        }
       end
 
       # Returns a Hash of fonts that are available to this page
@@ -29,7 +36,9 @@ module PDF
       #       of calling it over and over.
       #
       def fonts
-        @objects.deref!(resources[:Font]) || {}
+        (@objects.deref!(@resources[:Font]) || {}).tap { |obj|
+          PDF::Reader::Error.validate_type_as_malformed(obj, "Fonts dictionary", Hash)
+        }
       end
 
       # Returns a Hash of external graphic states that are available to this
@@ -40,7 +49,9 @@ module PDF
       #       of calling it over and over.
       #
       def graphic_states
-        @objects.deref!(resources[:ExtGState]) || {}
+        (@objects.deref!(@resources[:ExtGState]) || {}).tap { |obj|
+          PDF::Reader::Error.validate_type_as_malformed(obj, "ExtGState dictionary", Hash)
+        }
       end
 
       # Returns a Hash of patterns that are available to this page
@@ -50,7 +61,9 @@ module PDF
       #       of calling it over and over.
       #
       def patterns
-        @objects.deref!(resources[:Pattern]) || {}
+        (@objects.deref!(@resources[:Pattern]) || {}).tap { |obj|
+          PDF::Reader::Error.validate_type_as_malformed(obj, "Patterns dictionary", Hash)
+        }
       end
 
       # Returns an Array of procedure sets that are available to this page
@@ -60,7 +73,9 @@ module PDF
       #       of calling it over and over.
       #
       def procedure_sets
-        @objects.deref!(resources[:ProcSet]) || []
+        (@objects.deref!(@resources[:ProcSet]) || []).tap { |obj|
+          PDF::Reader::Error.validate_type_as_malformed(obj, "ProcSet array", Array)
+        }
       end
 
       # Returns a Hash of properties sets that are available to this page
@@ -70,7 +85,9 @@ module PDF
       #       of calling it over and over.
       #
       def properties
-        @objects.deref!(resources[:Properties]) || {}
+        (@objects.deref!(@resources[:Properties]) || {}).tap { |obj|
+          PDF::Reader::Error.validate_type_as_malformed(obj, "Properties dictionary", Hash)
+        }
       end
 
       # Returns a Hash of shadings that are available to this page
@@ -80,7 +97,9 @@ module PDF
       #       of calling it over and over.
       #
       def shadings
-        @objects.deref!(resources[:Shading]) || {}
+        (@objects.deref!(@resources[:Shading]) || {}).tap { |obj|
+          PDF::Reader::Error.validate_type_as_malformed(obj, "Shading dictionary", Hash)
+        }
       end
 
       # Returns a Hash of XObjects that are available to this page
@@ -90,7 +109,9 @@ module PDF
       #       of calling it over and over.
       #
       def xobjects
-        @objects.deref!(resources[:XObject]) || {}
+        (@objects.deref!(@resources[:XObject]) || {}).tap { |obj|
+          PDF::Reader::Error.validate_type_as_malformed(obj, "XObject dictionary", Hash)
+        }
       end
 
     end

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -270,6 +270,9 @@ module PDF
       sig { params(object: Object, name: String, klass: Module).void }
       def self.validate_type(object, name, klass); end
 
+      sig { params(object: Object, name: String, klass: Module).void }
+      def self.validate_type_as_malformed(object, name, klass); end
+
       sig { params(object: Object, name: String).void }
 		  def self.validate_not_nil(object, name); end
     end
@@ -784,6 +787,9 @@ module PDF
       sig { returns(T::Hash[Symbol, T.untyped]) }
       def attributes; end
 
+      sig { returns(T::Hash[Symbol, PDF::Reader::Font]) }
+      def fonts; end
+
       sig { returns(Numeric) }
       def height; end
 
@@ -820,7 +826,7 @@ module PDF
       sig { returns(T::Hash[Symbol, T.untyped]) }
       def root; end
 
-      sig { returns(T::Hash[Symbol, T.untyped]) }
+      sig { returns(PDF::Reader::Resources) }
       def resources; end
 
       sig { params(receivers: T.untyped, instructions: T.untyped).returns(T.untyped) }

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -787,9 +787,6 @@ module PDF
       sig { returns(T::Hash[Symbol, T.untyped]) }
       def attributes; end
 
-      sig { returns(T::Hash[Symbol, PDF::Reader::Font]) }
-      def fonts; end
-
       sig { returns(Numeric) }
       def height; end
 


### PR DESCRIPTION
This means I can easily add type annotations to the methods, at the cost of a bit of repetition.