### PR TITLE
Enable type checking of the CMap class

### DIFF
--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -173,10 +173,12 @@ module PDF
       attr_reader :map
 
       sig { params(data: String).void }
-      def initialize(data); end
+      def initialize(data)
+        @map = T.let(T.unsafe(nil), T::Hash[Integer, T::Array[Integer]])
+      end
 
-      sig { params(data: String).void }
-      def process_data(data); end
+      sig { params(data: String, initial_mode: Symbol).void }
+      def process_data(data, initial_mode = :none); end
 
       sig { returns(Integer) }
       def size; end
@@ -184,22 +186,22 @@ module PDF
       sig { params(c: Integer).returns(T::Array[Integer]) }
       def decode(c); end
 
-      sig { params(instructions: T.untyped).returns(T.untyped) }
+      sig { params(instructions: String).returns(PDF::Reader::Parser) }
       def build_parser(instructions); end
 
-      sig { params(str: T.untyped).returns(T.untyped) }
+      sig { params(str: String).returns(T::Array[Integer]) }
       def str_to_int(str); end
 
-      sig { params(instructions: T.untyped).returns(T.untyped) }
+      sig { params(instructions: T::Array[String]).void }
       def process_bfchar_instructions(instructions); end
 
-      sig { params(instructions: T.untyped).returns(T.untyped) }
+      sig { params(instructions: T::Array[T.any(T::Array[String], String)]).void }
       def process_bfrange_instructions(instructions); end
 
-      sig { params(start_code: T.untyped, end_code: T.untyped, dst: T.untyped).returns(T.untyped) }
+      sig { params(start_code: String, end_code: String, dst: String).void }
       def bfrange_type_one(start_code, end_code, dst); end
 
-      sig { params(start_code: T.untyped, end_code: T.untyped, dst: T.untyped).returns(T.untyped) }
+      sig { params(start_code: String, end_code: String, dst: T::Array[String]).void }
       def bfrange_type_two(start_code, end_code, dst); end
     end
 


### PR DESCRIPTION
This was originally skipped in #361 because I was getting an unreachable code error. I found it was possible to avoid that by providing a type annotation for the `mode` variable of the state machine instead of hard coding it to `:none`.

Sadly, I can't do the type annotation with `T.let()` because sorbet isn't a runtime dependency of pdf-reader, but I can hack it in via a sig in the RBI file if I make the initial state part of the method params.

I think this might be a sorbet bug: https://github.com/sorbet/sorbet/issues/4174#issuecomment-1014923965.

This was prompted by @bcoles highlighting some crashes via a fuzzer in  https://github.com/yob/pdf-reader/pull/421#issuecomment-1012591423 - I was curious to see if fully typing the CMap class would avoid the fuzzer crashes in that class.

For this particular class at least, it did. I modified the fuzzer in #248 like this and ran it for ~15 mins. No exceptions were raised from the CMap class.

```diff
diff --git a/tools/fuzz.rb b/tools/fuzz.rb
index ab81840..e87fbc6 100755
--- a/tools/fuzz.rb
+++ b/tools/fuzz.rb
@@ -182,7 +182,7 @@ def parse(reader)
   contents = ''
   reader.pages.each do |page|
     contents << page.fonts.to_s
-    contents << page.text.force_encoding('utf-8')
+    contents << page.text #.force_encoding('utf-8')
     contents << page.raw_content.force_encoding('utf-8')
   end
   # puts contents if VERBOSE
@@ -203,12 +203,14 @@ def summary
 # and save fuzz test case and backtrace to OUTPUT_DIR
 #
 def report_crash(e)
-  puts " - #{e.message}"
-  puts e.backtrace.first
-  fname = "#{DateTime.now.strftime('%Y%m%d%H%M%S%N')}_crash_#{rand(1000)}"
-  FileUtils.mv @fuzz_outfile, "#{OUTPUT_DIR}/#{fname}.pdf"
-  File.open("#{OUTPUT_DIR}/#{fname}.pdf.trace", 'w') do |file|
-    file.write "#{e.message}\n#{e.backtrace.join "\n"}"
+  if e.backtrace.any? { |l| l.include?("cmap") }
+    puts " - #{e.message}"
+    puts e.backtrace.first
+    fname = "#{DateTime.now.strftime('%Y%m%d%H%M%S%N')}_crash_#{rand(1000)}"
+    FileUtils.mv @fuzz_outfile, "#{OUTPUT_DIR}/#{fname}.pdf"
+    File.open("#{OUTPUT_DIR}/#{fname}.pdf.trace", 'w') do |file|
+      file.write "#{e.message}\n#{e.backtrace.join "\n"}"
+    end
   end
 end
```