### PR TITLE
Make an effort to compensate when an xref offset is a few bytes too low

### DIFF
--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -96,7 +96,13 @@ class PDF::Reader
     # id  - the object ID to return
     # gen - the object revision number to return
     def object(id, gen)
-      Error.assert_equal(parse_token, id)
+      idCheck = parse_token
+
+      # Sometimes the xref table is corrupt and points to an offset slightly too early in the file.
+      # check the next token, maybe we can find the start of the object we're looking for
+      if idCheck != id
+        Error.assert_equal(parse_token, id)
+      end
       Error.assert_equal(parse_token, gen)
       Error.str_assert(parse_token, "obj")
 

--- a/spec/data/invalid/xref_offset_too_low.pdf
+++ b/spec/data/invalid/xref_offset_too_low.pdf
@@ -1,0 +1,73 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 210
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<5468652078726566206f66667365742066> 30 <6f722074686520726f6f74206f626a65637420286f626a20322920697320612066> 30 <65> 20 <772062> 20 <7974657320746f6f206c6f> 15 <77>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000106 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000476 00000 n 
+0000000742 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+839
+%%EOF

--- a/spec/integration_invalid_spec.rb
+++ b/spec/integration_invalid_spec.rb
@@ -314,6 +314,22 @@ describe PDF::Reader, "integration specs with invalid PDF files" do
     end
   end
 
+  context "xref_offset_too_low.pdf" do
+    let(:filename) { pdf_spec_file("xref_offset_too_low") }
+
+    it "compensates for the error and can extract the paage text" do
+      expect {
+        parse_pdf(filename)
+      }.to_not raise_error
+
+      PDF::Reader.open(filename) do |pdf|
+        expect(pdf.page(1).text).to eql(
+          "The xref offset for the root object (obj 2) is a few bytes too low"
+        )
+      end
+    end
+  end
+
   # a very basic sanity check that we can open this file and extract interesting data
   def parse_pdf(filename)
     PDF::Reader.open(filename) do |reader|

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -308,6 +308,9 @@ data/invalid/trailer_is_not_a_dict.pdf:
 data/invalid/trailer_root_is_not_a_dict.pdf:
   :bytes: 108807
   :md5: e00b7fc6999ca722aa31d2bb90f1e5d0
+data/invalid/xref_offset_too_low.pdf:
+  :bytes: 1054
+  :md5: d3c06fd6d670b0bed3b6347b5c4561a2
 data/invisible.pdf:
   :bytes: 14364
   :md5: 563f7ec8eb2c4d54f00fd85d807580c0


### PR DESCRIPTION
A sample file provided in #213 has an xref table where at least one of the byte offsets is a few bytes too low. When we jump to that offset, we don't find the start of the object as we expect.

However, the following token in the file is the start of the expected object. Other readers I tested with seem to handle this particular corruption gracefully, and now we do too.

Fixes #213