### PR TITLE
Gracefully handle streams with a missing endobj token

### DIFF
--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -228,7 +228,10 @@ class PDF::Reader
       data = @buffer.read(length, :skip_eol => true)
 
       Error.str_assert(parse_token, "endstream")
-      Error.str_assert(parse_token, "endobj")
+
+      # We used to assert that the stream had the correct closing token, but it doesn't *really*
+      # matter if it's missing, and other readers seems to handle its absence just fine
+      # Error.str_assert(parse_token, "endobj")
 
       PDF::Reader::Stream.new(dict, data)
     end

--- a/spec/data/invalid/stream_missing_endobj.pdf
+++ b/spec/data/invalid/stream_missing_endobj.pdf
@@ -1,0 +1,73 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 160
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<4f626a65637420342028636f6e74656e742073747265616d29206973206d697373696e672074686520656e646f626a20746f6b> 20 <656e>] TJ
+ET
+
+Q
+
+endstream
+
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000420 00000 n 
+0000000686 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+783
+%%EOF

--- a/spec/integration_invalid_spec.rb
+++ b/spec/integration_invalid_spec.rb
@@ -330,6 +330,22 @@ describe PDF::Reader, "integration specs with invalid PDF files" do
     end
   end
 
+  context "stream_missing_endobj.pdf" do
+    let(:filename) { pdf_spec_file("stream_missing_endobj") }
+
+    it "compensates for the error and can extract the paage text" do
+      expect {
+        parse_pdf(filename)
+      }.to_not raise_error
+
+      PDF::Reader.open(filename) do |pdf|
+        expect(pdf.page(1).text).to eql(
+          "Object 4 (content stream) is missing the endobj token"
+        )
+      end
+    end
+  end
+
   # a very basic sanity check that we can open this file and extract interesting data
   def parse_pdf(filename)
     PDF::Reader.open(filename) do |reader|

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -302,6 +302,9 @@ data/invalid/no_trailer.pdf:
 data/invalid/page_reference_is_not_a_dict.pdf:
   :bytes: 108807
   :md5: 7a6da0a240b4c3dea52308502b051cb5
+data/invalid/stream_missing_endobj.pdf:
+  :bytes: 998
+  :md5: 624687838f3445a4bd8a1f8dafe65810
 data/invalid/trailer_is_not_a_dict.pdf:
   :bytes: 9651
   :md5: 2cf861306cb9d19e926a079f54ad4e19


### PR DESCRIPTION
There no reason this token really needs to be there, we can parse the file just fine if it's missing for some reason. Other readers (inc. Acrobat) handle it, so we can too.

Fixes #138