### PR TITLE
PDF::Reader::ObjectHash#page_references should return an array of PDF::Reader::Reference

### DIFF
--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -571,12 +571,14 @@ class PDF::Reader
     # the Array is significant and matches the page ordering of the document
     #
     def get_page_objects(obj)
-      if obj[:Type] == :Page
+      derefed_obj = deref_hash(obj)
+
+      if derefed_obj[:Type] == :Page
         [obj]
-      elsif obj[:Kids]
-        kids = deref_array(obj[:Kids]) || []
+      elsif derefed_obj[:Kids]
+        kids = deref_array(derefed_obj[:Kids]) || []
         kids.map { |kid|
-          get_page_objects(deref_hash(kid) || {})
+          get_page_objects(kid)
         }.flatten
       else
         raise MalformedPDFError, "Expected Page or Pages object"

--- a/spec/object_hash_spec.rb
+++ b/spec/object_hash_spec.rb
@@ -375,6 +375,15 @@ describe PDF::Reader::ObjectHash do
 
   describe "#page_references" do
 
+    it "returns an Array of PDF::Reader::Reference objs" do
+      filename = pdf_spec_file("cairo-unicode")
+      h = PDF::Reader::ObjectHash.new(filename)
+      expect(h.page_references).to be_a(Array)
+      h.page_references.each do |ref|
+        expect(ref).to be_a(PDF::Reader::Reference)
+      end
+    end
+
     it "raises a MalformedPDFError if dereferenced value is not a dict" do
       filename = pdf_spec_file("page_reference_is_not_a_dict")
       h = PDF::Reader::ObjectHash.new(filename)


### PR DESCRIPTION
In #421 I refactored PDF::Reader::ObjectHash to check they types of
objects in pulls from the PDF file and raise when the object type is the
wrong type.

In doing so, I inadvertently changed the page_references method to
return an Array of PDF::Reader::Page objects, rather than the indirect
references to them.

For most users it won't matter, but it might for some so it's a bug.

Interestingly, the RBI file already claims this method must return an
array of PDF::Reader::Reference objects and the sorbet static type
checks weren't failing.

Fixes #443