### PR TITLE
Reader: LZW: create_new_string: Coerce nil string_table code to string

### DIFF
--- a/lib/pdf/reader/lzw.rb
+++ b/lib/pdf/reader/lzw.rb
@@ -119,8 +119,8 @@ module PDF
         result
       end
 
-      def self.create_new_string(string_table,some_code, other_code)
-        string_table[some_code] + string_table[other_code][0].chr
+      def self.create_new_string(string_table, some_code, other_code)
+        string_table[some_code].to_s + string_table[other_code][0].chr
       end
       private_class_method :create_new_string
 


### PR DESCRIPTION
I was looking through some of the crashes identified by the fuzzer and this looked like an easy fix, but relying on your experience with PDF format to confirm this is a reasonable fix.

Perhaps LZW decompression should be a fatal error. However, other PDF readers will at least render the document, even if it is clearly broken:

![image](https://user-images.githubusercontent.com/434827/163707705-917fb0b0-9b6c-4143-9926-4b42d004b3a1.png)



---

[20220417004840082938521_crash_346.pdf](https://github.com/yob/pdf-reader/files/8501259/20220417004840082938521_crash_346.pdf)

```
crashes/20220417004840082938521_crash_346.pdf.trace-1-undefined method `+' for nil:NilClass
crashes/20220417004840082938521_crash_346.pdf.trace:2:/var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/lzw.rb:123:in `create_new_string'
```

```
$ ./tools/read-pdf.rb crashes/20220417004840082938521_crash_346.pdf
[*] Processing 'crashes/20220417004840082938521_crash_346.pdf'
[+] Processing complete
[*] Parsing 'crashes/20220417004840082938521_crash_346.pdf'
[*] Version: 1.4
[*] Info: {:Creator=>"pdftk 1.41 - www.pdftk.com", :Producer=>"iText 2.1.7 by 1T3XT", :ModDate=>"D:20101113061857-06'00'", :CreationDate=>"D:20101113061857-06'00'"}
[*] Metadata: 
[*] Objects: <PDF::Reader::ObjectHash size: 8>
[*] Pages: 1
[*] Parsing PDF contents...
Traceback (most recent call last):
	16: from ./tools/read-pdf.rb:109:in `<main>'
	15: from ./tools/read-pdf.rb:59:in `read'
	14: from ./tools/read-pdf.rb:81:in `parse'
	13: from ./tools/read-pdf.rb:81:in `each'
	12: from ./tools/read-pdf.rb:82:in `block in parse'
	11: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/page.rb:115:in `text'
	10: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/page.rb:159:in `walk'
	 9: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/page.rb:169:in `raw_content'
	 8: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/page.rb:169:in `map'
	 7: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/page.rb:170:in `block in raw_content'
	 6: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/stream.rb:64:in `unfiltered_data'
	 5: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/stream.rb:64:in `each_with_index'
	 4: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/stream.rb:64:in `each'
	 3: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/stream.rb:65:in `block in unfiltered_data'
	 2: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/filter/lzw.rb:18:in `filter'
	 1: from /var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/lzw.rb:101:in `decode'
/var/lib/gems/2.7.0/gems/pdf-reader-2.9.2/lib/pdf/reader/lzw.rb:123:in `create_new_string': undefined method `+' for nil:NilClass (NoMethodError)
```

After this PR the page text contains PDF data. This is in line with behaviour of other PDF readers.

```
$ ./tools/read-pdf.rb crashes/20220417004840082938521_crash_346.pdf
[*] Processing 'crashes/20220417004840082938521_crash_346.pdf'
[+] Processing complete
[*] Parsing 'crashes/20220417004840082938521_crash_346.pdf'
[*] Version: 1.4
[*] Info: {:Creator=>"pdftk 1.41 - www.pdftk.com", :Producer=>"iText 2.1.7 by 1T3XT", :ModDate=>"D:20101113061857-06'00'", :CreationDate=>"D:20101113061857-06'00'"}
[*] Metadata: 
[*] Objects: <PDF::Reader::ObjectHash size: 8>
[*] Pages: 1
[*] Parsing PDF contents...
[*] Page text
%PDF-1.2
%âãÏÓ

10 0 obj
<<
/OOOngth 11 0 R

/Filter /OZWDecode
>>
stream
 €▯Š€Ñ˜Ôf.▯
[*] Page fonts
{:F0=>{:FirstChar=>32, :Encoding=>:WinAnsiEncoding, :Name=>:F0, :FontDescriptor=>{:FontName=>:CourierNew, :StemV=>109, :Leading=>133, :Ascent=>833, :Flags=>34, :XHeight=>417, :AvgWidth=>600, :Descent=>-300, :ItalicAngle=>0, :StemH=>109, :MissingWidth=>595, :"MaxW^dth"=>595, :FontBBox=>[-250, -300, 714, 1000], :Type=>:FontDescriptor, :CapHeight=>833}, :BaseFont=>:CourierNew, :Subtype=>:TrueType, :LastChar=>255, :Widths=>[595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595, 595], :Type=>:Font}}
[*] Page raw_content
ET031) Tj(\321\230\324f.) Tj0 0 obj) Tj
[+] Parsing complete
```
