### PR TITLE
Add sorbet types for PDF::Font and PDF::Reader::WidthCalculators::*

### DIFF
--- a/lib/pdf/reader/width_calculator/built_in.rb
+++ b/lib/pdf/reader/width_calculator/built_in.rb
@@ -53,12 +53,13 @@ class PDF::Reader
       private
 
       def control_character?(code_point)
-        @font.encoding.int_to_name(code_point).first.to_s[/\Acontrol..\Z/]
+        match = @font.encoding.int_to_name(code_point).first.to_s[/\Acontrol..\Z/]
+        match ? true : false
       end
 
       def extract_basefont(font_name)
         if BUILTINS.include?(font_name)
-          font_name
+          font_name.to_s
         else
           "Times-Roman"
         end

--- a/lib/pdf/reader/width_calculator/composite.rb
+++ b/lib/pdf/reader/width_calculator/composite.rb
@@ -22,7 +22,11 @@ class PDF::Reader
 
         w = @widths[code_point]
         # 0 is a valid width
-        return w.to_f unless w.nil?
+        if w
+          w.to_f
+        else
+          0
+        end
       end
     end
   end

--- a/lib/pdf/reader/width_calculator/true_type.rb
+++ b/lib/pdf/reader/width_calculator/true_type.rb
@@ -10,8 +10,8 @@ class PDF::Reader
       def initialize(font)
         @font = font
 
-        if @font.font_descriptor
-          @missing_width = @font.font_descriptor.missing_width
+        if fd = @font.font_descriptor
+          @missing_width = fd.missing_width
         else
           @missing_width = 0
         end
@@ -30,8 +30,9 @@ class PDF::Reader
 
         # in ruby a negative index is valid, and will go from the end of the array
         # which is undesireable in this case.
-        if @font.first_char && @font.first_char <= code_point
-          @font.widths.fetch(code_point - @font.first_char, @missing_width).to_f
+        first_char = @font.first_char
+        if first_char && first_char <= code_point
+          @font.widths.fetch(code_point - first_char, @missing_width).to_f
         else
           @missing_width.to_f
         end
@@ -44,11 +45,10 @@ class PDF::Reader
         # with-in a program inside the font descriptor, however the widths
         # may not be in standard PDF glyph widths (1000 units => 1 text space unit)
         # so this width will need to be scaled
-        w = @font.font_descriptor.glyph_width(code_point)
-        if w
-          w.to_f * @font.font_descriptor.glyph_to_pdf_scale_factor
-        else
-          nil
+        if fd = @font.font_descriptor
+          if w = fd.glyph_width(code_point)
+            w.to_f * fd.glyph_to_pdf_scale_factor
+          end
         end
       end
     end

--- a/lib/pdf/reader/width_calculator/type_one_or_three.rb
+++ b/lib/pdf/reader/width_calculator/type_one_or_three.rb
@@ -10,8 +10,8 @@ class PDF::Reader
       def initialize(font)
         @font = font
 
-        if @font.font_descriptor
-          @missing_width = @font.font_descriptor.missing_width
+        if fd = @font.font_descriptor
+          @missing_width = fd.missing_width
         else
           @missing_width = 0
         end
@@ -23,8 +23,9 @@ class PDF::Reader
 
         # in ruby a negative index is valid, and will go from the end of the array
         # which is undesireable in this case.
-        if @font.first_char && @font.first_char <= code_point
-          @font.widths.fetch(code_point - @font.first_char, @missing_width).to_f
+        first_char = @font.first_char
+        if first_char && first_char <= code_point
+          @font.widths.fetch(code_point - first_char, @missing_width).to_f
         else
           @missing_width.to_f
         end

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -300,37 +300,37 @@ module PDF
     end
 
     class Font
-      sig { returns(T.untyped) }
+      sig { returns(T.nilable(Symbol)) }
       attr_accessor :subtype
 
-      sig { returns(T.untyped) }
+      sig { returns(PDF::Reader::Encoding) }
       attr_accessor :encoding
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Array[PDF::Reader::Font]) }
       attr_accessor :descendantfonts
 
-      sig { returns(T.untyped) }
+      sig { returns(PDF::Reader::CMap) }
       attr_accessor :tounicode
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Array[Integer]) }
       attr_reader :widths
 
-      sig { returns(T.untyped) }
+      sig { returns(T.nilable(Integer)) }
       attr_reader :first_char
 
-      sig { returns(T.untyped) }
+      sig { returns(T.nilable(Integer)) }
       attr_reader :last_char
 
-      sig { returns(T.untyped) }
+      sig { returns(T.nilable(Symbol)) }
       attr_reader :basefont
 
-      sig { returns(T.untyped) }
+      sig { returns(T.nilable(PDF::Reader::FontDescriptor)) }
       attr_reader :font_descriptor
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Array[Numeric]) }
       attr_reader :cid_widths
 
-      sig { returns(T.untyped) }
+      sig { returns(Numeric) }
       attr_reader :cid_default_width
 
       sig { params(ohash: T.untyped, obj: T.untyped).void }
@@ -1923,54 +1923,64 @@ module PDF
         :ZapfDingbats
       ]
 
-        sig { params(font: T.untyped).void }
-        def initialize(font); end
+        sig { params(font: PDF::Reader::Font).void }
+        def initialize(font)
+          @font = T.let(T.unsafe(nil), PDF::Reader::Font)
+        end
 
-        sig { params(code_point: T.untyped).returns(T.untyped) }
+        sig { params(code_point: T.nilable(Integer)).returns(Numeric) }
         def glyph_width(code_point); end
 
-        sig { params(code_point: T.untyped).returns(T.untyped) }
+        sig { params(code_point: Integer).returns(T::Boolean) }
         def control_character?(code_point); end
 
-        sig { params(font_name: T.untyped).returns(T.untyped) }
+        sig { params(font_name: T.nilable(Symbol)).returns(String) }
         def extract_basefont(font_name); end
       end
 
       class Composite
-        sig { params(font: T.untyped).void }
-        def initialize(font); end
+        sig { params(font: PDF::Reader::Font).void }
+        def initialize(font)
+          @font = T.let(T.unsafe(nil), PDF::Reader::Font)
+        end
 
-        sig { params(code_point: T.untyped).returns(T.untyped) }
+        sig { params(code_point: T.nilable(Integer)).returns(Numeric) }
         def glyph_width(code_point); end
       end
 
       class TrueType
-        sig { params(font: T.untyped).void }
-        def initialize(font); end
+        sig { params(font: PDF::Reader::Font).void }
+        def initialize(font)
+          @font = T.let(T.unsafe(nil), PDF::Reader::Font)
+        end
 
-        sig { params(code_point: T.untyped).returns(T.untyped) }
+        sig { params(code_point: T.nilable(Integer)).returns(Numeric) }
         def glyph_width(code_point); end
 
-        sig { params(code_point: T.untyped).returns(T.untyped) }
+        sig { params(code_point: Integer).returns(T.nilable(Numeric)) }
         def glyph_width_from_font(code_point); end
 
-        sig { params(code_point: T.untyped).returns(T.untyped) }
+        sig { params(code_point: Integer).returns(T.nilable(Numeric)) }
         def glyph_width_from_descriptor(code_point); end
       end
 
       class TypeOneOrThree
-        sig { params(font: T.untyped).void }
-        def initialize(font); end
+        sig { params(font: PDF::Reader::Font).void }
+        def initialize(font)
+          @font = T.let(T.unsafe(nil), PDF::Reader::Font)
+        end
 
-        sig { params(code_point: T.untyped).returns(T.untyped) }
+        sig { params(code_point: T.nilable(Integer)).returns(Numeric) }
         def glyph_width(code_point); end
       end
 
       class TypeZero
-        sig { params(font: T.untyped).void }
-        def initialize(font); end
+        sig { params(font: PDF::Reader::Font).void }
+        def initialize(font)
+          @font = T.let(T.unsafe(nil), PDF::Reader::Font)
+        end
 
-        sig { params(code_point: T.untyped).returns(T.untyped) }
+        sig { params(code_point: T.nilable(Integer)).returns(Numeric) }
         def glyph_width(code_point); end
       end
     end


### PR DESCRIPTION
Slowly filling in type annotations, with the theory I'll eventually pass critical mass and flush out some bugs.

Prompted by @bcoles PR #448, which fixed the kind of bug that sorbet typing **should** make impossible.