### PR TITLE
add some nil safety to LZW decompression

### DIFF
--- a/lib/pdf/reader/lzw.rb
+++ b/lib/pdf/reader/lzw.rb
@@ -119,8 +119,15 @@ module PDF
         result
       end
 
-      def self.create_new_string(string_table,some_code, other_code)
-        string_table[some_code] + string_table[other_code][0].chr
+      def self.create_new_string(string_table, some_code, other_code)
+        item_one = string_table[some_code]
+        item_two = string_table[other_code]
+
+        if item_one && item_two
+          item_one + item_two[0].chr
+        else
+          raise MalformedPDFError, "invalid LZW data"
+        end
       end
       private_class_method :create_new_string
 

--- a/spec/data/lzw_compressed_corrupt.dat
+++ b/spec/data/lzw_compressed_corrupt.dat
@@ -1,0 +1,2 @@
+€Š€Ñ°Ø@7ŒEÐaPˆ"1‘œ@‘¢#€¸`8CLÀÑlt`4CLq)	Pî 	JB0¶2ÃMQÚo)‡L¥Á˜ÐeDèƒ½d3œ•'qð¸j2–‘%•Q•´(ŽKæ#UFvTLƒË06Ñ0“÷¦ã9ÐÐ „Ë
+VÛx¢2i6§!Ä´W"Lfó!–ÛT„Õ«Úøø}žäkµ™Ìèr2˜M·ËL#”˜C…´P\jõÚ¡Œât×êõ»qÒY¨×ŒÆCPÌaN…Û1€Ìcm"Àà 

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -338,6 +338,9 @@ data/lzw_compressed.dat:
 data/lzw_compressed2.dat:
   :bytes: 7279
   :md5: 77d850609610846d06dac6b80b10c25a
+data/lzw_compressed_corrupt.dat:
+  :bytes: 238
+  :md5: 254d00a22e904863dee946a4da7eda68
 data/lzw_decompressed.dat:
   :bytes: 347
   :md5: 4abd51aa78c14ed837d834e181216787

--- a/spec/lzw_spec.rb
+++ b/spec/lzw_spec.rb
@@ -16,5 +16,13 @@ describe PDF::Reader::LZW do
 
       expect(PDF::Reader::LZW.decode(content)).to match(/\ABT/)
     end
+
+    it "raises PDF::Reader::MalformedPDFError when the stream isn't valid lzw" do
+      content = binread(File.dirname(__FILE__) + "/data/lzw_compressed_corrupt.dat")
+
+      expect {
+        PDF::Reader::LZW.decode(content)
+      }.to raise_error(PDF::Reader::MalformedPDFError)
+    end
   end
 end


### PR DESCRIPTION
Based on the data provided in #449.

For now I think I'd prefer to err on the side of strictness and raise
one of our documented errors when a PDF file contains invalid LZW
compressed data.

I'm mulling over how to handle this sort of issue long term though. It's
definitely true that other PDF readers tend to treat this kind of thing
as a soft error and do their best to render the rest of the page anyway.