### PR TITLE
nil safety in WidthCalculator::TypeZero

### DIFF
--- a/lib/pdf/reader/width_calculator/type_zero.rb
+++ b/lib/pdf/reader/width_calculator/type_zero.rb
@@ -13,13 +13,16 @@ class PDF::Reader
 
       def initialize(font)
         @font = font
-        @descendant_font = @font.descendantfonts.first
       end
 
       def glyph_width(code_point)
         return 0 if code_point.nil? || code_point < 0
 
-        @descendant_font.glyph_width(code_point).to_f
+        if descendant_font = @font.descendantfonts.first
+          descendant_font.glyph_width(code_point).to_f
+        else
+          0
+        end
       end
     end
   end


### PR DESCRIPTION
A Type0 font with no descendants is invalid, but it's syntactically very possible for the DescendantFonts array of a Font object to have 0 items.

We need to confirm the descendant exists before we delegate to it.

Fixes #453