### PR TITLE
Don't pass nil to Font.new when parsing XObjects

### DIFF
--- a/lib/pdf/reader/form_xobject.rb
+++ b/lib/pdf/reader/form_xobject.rb
@@ -45,7 +45,7 @@ module PDF
       def font_objects
         raw_fonts = @objects.deref_hash(fonts)
         ::Hash[raw_fonts.map { |label, font|
-          [label, PDF::Reader::Font.new(@objects, @objects.deref_hash(font))]
+          [label, PDF::Reader::Font.new(@objects, @objects.deref_hash(font) || {})]
         }]
       end
 


### PR DESCRIPTION
`@objects.deref_hash()` can return nil, but Font.new doesn't handle a nil second arg very well.

As a general rule  `@objects.deref_hash()` will not return nil. If it does, it's probably a corrupt file, so this is an edge case.

This matches the way we initialize Font objects in PageState as well.