### PR TITLE
Validate callbacks when extracting text from a form xobject

### DIFF
--- a/lib/pdf/reader/form_xobject.rb
+++ b/lib/pdf/reader/form_xobject.rb
@@ -55,6 +55,9 @@ module PDF
       # See the comments on PDF::Reader::Page#walk for more detail.
       #
       def walk(*receivers)
+        receivers = receivers.map { |receiver|
+          ValidatingReceiver.new(receiver)
+        }
         content_stream(receivers, raw_content)
       end
 


### PR DESCRIPTION
This mirrors the change made in #437 for standard page content that's not in a form xobject.

The commit message there is also relevant here:

> `Page#walk` will execute the content stream of a page, calling methods on a receiver class provided by the user. Each operator has a specific set of parameters it expects, and we wrap the users receiver class in this one to verify the PDF uses valid parameters.
>
> Without these checks, users can't be confident about the number of parameters they'll receive for an operator, or what the type of those parameters will be. Everyone ends up building their own type safety guard clauses and it's tedious.
>
> Not all operators have type safety implemented yet, but we can expand the number over time.
>
> This fixes a large number of potential crashes exposed by the fuzzer added in #429. When it flips bits in some content streams the parameters that are passed to receivers can change in number of type, raising exceptions we don't want to raise (like NoMethodError).