### PR TITLE
Extra nil safety in PageState

### DIFF
--- a/lib/pdf/reader/page_state.rb
+++ b/lib/pdf/reader/page_state.rb
@@ -16,7 +16,7 @@ class PDF::Reader
         :h_scaling      => 1.0,
         :text_leading   => 0,
         :text_font      => nil,
-        :text_font_size => nil,
+        :text_font_size => 0,
         :text_mode      => 0,
         :text_rise      => 0,
         :text_knockout  => 0
@@ -32,6 +32,12 @@ class PDF::Reader
         @cs_stack      = [page.color_spaces]
         @stack         = [DEFAULT_GRAPHICS_STATE.dup]
         state[:ctm]  = identity_matrix
+
+        # These are only valid when inside a `BT` block and we re-initialize them on each
+        # `BT`. However, we need the instance variables set so PDFs with the text operators
+        # out order don't trigger NoMethodError when these are nil
+        @text_matrix      = identity_matrix
+        @text_line_matrix = identity_matrix
       end
 
       #####################################################

--- a/spec/page_state_spec.rb
+++ b/spec/page_state_spec.rb
@@ -209,6 +209,16 @@ describe PDF::Reader::PageState do
         expect(state.trm_transform(1,1)).to eq([17, 22])
       end
     end
+
+    context "without begin_text first (out of order)" do
+      let!(:state)  {PDF::Reader::PageState.new(page) }
+
+      it "doesn't raise an exception" do
+        expect {
+          state.move_text_position(5, 10)
+        }.to_not raise_error
+      end
+    end
   end
 
   describe "#move_text_position_and_set_leading" do
@@ -235,6 +245,15 @@ describe PDF::Reader::PageState do
         state.move_text_position_and_set_leading(5, 10)
 
         expect(state.clone_state[:text_leading]).to eq(-10)
+      end
+    end
+    context "without begin_text first (out of order)" do
+      let!(:state)  {PDF::Reader::PageState.new(page) }
+
+      it "doesn't raise an exception" do
+        expect {
+          state.move_text_position_and_set_leading(5, 10)
+        }.to_not raise_error
       end
     end
   end
@@ -278,6 +297,15 @@ describe PDF::Reader::PageState do
         expect(state.trm_transform(1,1)).to eq([12, -3])
       end
     end
+    context "without begin_text first (out of order)" do
+      let!(:state)  {PDF::Reader::PageState.new(page) }
+
+      it "doesn't raise an exception" do
+        expect {
+          state.move_to_start_of_next_line
+        }.to_not raise_error
+      end
+    end
   end
 
   describe "#move_to_next_line_and_show_text" do
@@ -297,6 +325,15 @@ describe PDF::Reader::PageState do
         expect(state.trm_transform(0,1)).to eq([0, -3])
         expect(state.trm_transform(1,0)).to eq([12, -15])
         expect(state.trm_transform(1,1)).to eq([12, -3])
+      end
+    end
+    context "without begin_text first (out of order)" do
+      let!(:state)  {PDF::Reader::PageState.new(page) }
+
+      it "doesn't raise an exception" do
+        expect {
+          state.move_to_next_line_and_show_text("Foo")
+        }.to_not raise_error
       end
     end
   end
@@ -352,6 +389,47 @@ describe PDF::Reader::PageState do
         expect(state.trm_transform(1,1)).to eq([12, 12])
       end
     end
+    context "without begin_text first (out of order)" do
+      let!(:state)  {PDF::Reader::PageState.new(page) }
+
+      it "doesn't raise an exception" do
+        expect {
+          state.set_spacing_next_line_show_text(10, 20, "test")
+        }.to_not raise_error
+      end
+    end
+  end
+
+  describe "#ctm_transform" do
+    # ctm_transform is mostly verified as correct via assertions in all the other specs of this
+    # class - it's one of the primary ways we can see the visible state. However we need to check
+    # some error conditions here
+
+    context "with an empty page" do
+      let!(:state)  {PDF::Reader::PageState.new(page) }
+
+      it "is a no-op" do
+        expect(state.trm_transform(0,0)).to eq([0, 0])
+      end
+    end
+
+  end
+
+  describe "#trm_transform" do
+    # trm_transform is mostly verified as correct via assertions in all the other specs of this
+    # class - it's one of the primary ways we can see the visible state. However we need to check
+    # some error conditions here
+
+    context "without begin_text first (out of order)" do
+      let!(:state)  {PDF::Reader::PageState.new(page) }
+
+      it "doesn't raise an exception" do
+        expect {
+          state.trm_transform(0,0)
+        }.to_not raise_error
+      end
+    end
+
   end
 
   describe "#process_glyph_displacement" do


### PR DESCRIPTION
Some of the text state operators mutate instance variables like @text_matrix and @text_line_matrix, and assume the instance variables exist.

In valid PDFs the text state operators that do so are within `BT` text block, so it's fine for us to initialize the instance variables there.

However, invalid PDFs (like those genrated by the fuzzer) might have text state operators without a preceding `BT` operator. For safety, initialize these vars in the constructor.