### PR TITLE
Runtime check to ensure PDF::Reader::Stream#hash is always a Hash

### DIFF
--- a/lib/pdf/reader/stream.rb
+++ b/lib/pdf/reader/stream.rb
@@ -40,7 +40,7 @@ class PDF::Reader
     # Creates a new stream with the specified dictionary and data. The dictionary
     # should be a standard ruby hash, the data should be a standard ruby string.
     def initialize(hash, data)
-      @hash = hash
+      @hash = TypeCheck.cast_to_pdf_dict!(hash)
       @data = data
       @udata = nil
     end

--- a/lib/pdf/reader/type_check.rb
+++ b/lib/pdf/reader/type_check.rb
@@ -46,6 +46,16 @@ module PDF
           raise MalformedPDFError, "Unable to cast to symbol"
         end
       end
+
+      def self.cast_to_pdf_dict!(obj)
+        if obj.is_a?(Hash)
+          obj
+        elsif obj.respond_to?(:to_h)
+          obj.to_h
+        else
+          raise MalformedPDFError, "Unable to cast to hash"
+        end
+      end
     end
   end
 end

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -1691,6 +1691,9 @@ module PDF
 
       sig { params(obj: T.untyped).returns(T.nilable(Symbol)) }
       def self.cast_to_symbol(obj); end
+
+      sig { params(obj: T.untyped).returns(T::Hash[Symbol, T.untyped]) }
+      def self.cast_to_pdf_dict!(obj); end
     end
 
     class ValidatingReceiver


### PR DESCRIPTION
Corrupt PDFs (like those generated by the fuzzer) might have an invalid type as the header object. We can't work with them - we need the Hash to fetch :Length and other properties. Best just to fail early and raise a MalformedPDFError