### PR TITLE
Fill in most type signatures on PDF::Reader::ObjectStream

### DIFF
--- a/lib/pdf/reader/object_stream.rb
+++ b/lib/pdf/reader/object_stream.rb
@@ -24,7 +24,7 @@ class PDF::Reader
     end
 
     def size
-      @dict[:N]
+      TypeCheck.cast_to_int!(@dict[:N])
     end
 
     private
@@ -40,7 +40,7 @@ class PDF::Reader
     end
 
     def first
-      @dict[:First]
+      TypeCheck.cast_to_int!(@dict[:First])
     end
 
     def buffer

--- a/lib/pdf/reader/type_check.rb
+++ b/lib/pdf/reader/type_check.rb
@@ -9,6 +9,18 @@ module PDF
     #
     class TypeCheck
 
+      def self.cast_to_int!(obj)
+        if obj.is_a?(Integer)
+          obj
+        elsif obj.nil?
+          0
+        elsif obj.respond_to?(:to_i)
+          obj.to_i
+        else
+          raise MalformedPDFError, "Unable to cast to integer"
+        end
+      end
+
       def self.cast_to_numeric!(obj)
         if obj.is_a?(Numeric)
           obj

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -772,22 +772,25 @@ module PDF
     end
 
     class ObjectStream
-      sig { params(stream: T.untyped).void }
-      def initialize(stream); end
+      sig { params(stream: PDF::Reader::Stream).void }
+      def initialize(stream)
+        @dict = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+        @data = T.let(T.unsafe(nil), String)
+      end
 
       sig { params(objid: T.untyped).returns(T.untyped) }
       def [](objid); end
 
-      sig { returns(T.untyped) }
+      sig { returns(Integer) }
       def size; end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Hash[Integer, Integer]) }
       def offsets; end
 
-      sig { returns(T.untyped) }
+      sig { returns(Integer) }
       def first; end
 
-      sig { returns(T.untyped) }
+      sig { returns(PDF::Reader::Buffer) }
       def buffer; end
     end
 
@@ -1682,6 +1685,9 @@ module PDF
     end
 
     class TypeCheck
+
+      sig { params(obj: T.untyped).returns(Integer) }
+      def self.cast_to_int!(obj); end
 
       sig { params(obj: T.untyped).returns(Numeric) }
       def self.cast_to_numeric!(obj); end


### PR DESCRIPTION
Avoid some crashes from corrupt PDFs with incorrect types