### PR TITLE
Change LZW implementation to `typed: strict`

### DIFF
--- a/lib/pdf/reader/lzw.rb
+++ b/lib/pdf/reader/lzw.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module PDF
@@ -41,7 +41,7 @@ module PDF
           chunk = -1
           while bits_left_in_chunk > 0 and @current_pos < @data.size
             chunk = 0 if chunk < 0
-            codepoint = @data[@current_pos, 1].unpack("C*")[0]
+            codepoint = @data[@current_pos, 1].to_s.unpack("C*")[0].to_i
             current_byte = codepoint & (2**@bits_left_in_byte - 1) #clear consumed bits
             dif = bits_left_in_chunk - @bits_left_in_byte
             if dif > 0 then  current_byte <<= dif
@@ -63,21 +63,25 @@ module PDF
       CODE_CLEAR_TABLE = 256 #clear table
 
       # stores de pairs code => string
-      class StringTable < Hash # :nodoc:
+      class StringTable
         attr_reader :string_table_pos
 
         def initialize
-          super
+          @data = Hash.new
           @string_table_pos = 258 #initial code
         end
 
         #if code less than 258 return fixed string
         def [](key)
-          if key > 257 then super else key.chr end
+          if key > 257
+            @data[key]
+          else
+            key.chr
+          end
         end
 
         def add(string)
-          store(@string_table_pos, string)
+          @data.store(@string_table_pos, string)
           @string_table_pos += 1
         end
       end

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -527,7 +527,13 @@ module PDF
 
       class BitStream
         sig { params(data: String, bits_in_chunk: Integer).void }
-        def initialize(data, bits_in_chunk); end
+        def initialize(data, bits_in_chunk)
+          @data = T.let(T.unsafe(nil), String)
+          @bits_in_chunk = T.let(T.unsafe(nil), Integer)
+          @current_pos = T.let(T.unsafe(nil), Integer)
+          @bits_left_in_byte = T.let(T.unsafe(nil), Integer)
+
+        end
 
         sig { params(bits_in_chunk: Integer).void }
         def set_bits_in_chunk(bits_in_chunk); end
@@ -536,12 +542,15 @@ module PDF
         def read; end
       end
 
-      class StringTable < Hash
-        sig { returns(T.untyped) }
+      class StringTable
+        sig { returns(Integer) }
         attr_reader :string_table_pos
 
         sig { void }
-        def initialize; end
+        def initialize
+          @data = T.let(T.unsafe(nil), T::Hash[Integer, String])
+          @string_table_pos = T.let(T.unsafe(nil), Integer)
+        end
 
         sig { params(key: Integer).returns(T.nilable(String)) }
         def [](key); end


### PR DESCRIPTION
Builds on the work in #455.

This required removing the subclassing of Hash, which is a better design anyway.