### PR TITLE
raise MalformedPDFError when depredict data is invalid

### DIFF
--- a/lib/pdf/reader/filter/depredict.rb
+++ b/lib/pdf/reader/filter/depredict.rb
@@ -125,7 +125,7 @@ class PDF::Reader
               row_data[index] = (byte + paeth) % 256
             end
           else
-            raise ArgumentError, "Invalid filter algorithm #{filter}"
+            raise MalformedPDFError, "Invalid filter algorithm #{filter}"
           end
 
           s = []


### PR DESCRIPTION
This class is processing untrusted user data from PDF files, and if the data is invalid we want to raise one of our documented exceptions - not `ArgumentError`