### PR TITLE
Fix broken type sigs for resource methods

### DIFF
--- a/lib/pdf/reader/resources.rb
+++ b/lib/pdf/reader/resources.rb
@@ -92,7 +92,8 @@ module PDF
       #       of calling it over and over.
       #
       def xobjects
-        @objects.deref_hash!(@resources[:XObject]) || {}
+        dict = @objects.deref_hash!(@resources[:XObject]) || {}
+        TypeCheck.cast_to_pdf_dict_with_stream_values!(dict)
       end
 
     end

--- a/lib/pdf/reader/type_check.rb
+++ b/lib/pdf/reader/type_check.rb
@@ -59,11 +59,35 @@ module PDF
         end
       end
 
+      def self.cast_to_symbol!(obj)
+        res = cast_to_symbol(obj)
+        if res
+          res
+        else
+          raise MalformedPDFError, "Unable to cast to symbol"
+        end
+      end
+
       def self.cast_to_pdf_dict!(obj)
         if obj.is_a?(Hash)
           obj
         elsif obj.respond_to?(:to_h)
           obj.to_h
+        else
+          raise MalformedPDFError, "Unable to cast to hash"
+        end
+      end
+
+      def self.cast_to_pdf_dict_with_stream_values!(obj)
+        if obj.is_a?(Hash)
+          result = Hash.new
+          obj.each do |k, v|
+            raise MalformedPDFError, "Expected a stream" unless v.is_a?(PDF::Reader::Stream)
+            result[cast_to_symbol!(k)] = v
+          end
+          result
+        elsif obj.respond_to?(:to_h)
+          cast_to_pdf_dict_with_stream_values!(obj.to_h)
         else
           raise MalformedPDFError, "Unable to cast to hash"
         end

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -690,10 +690,10 @@ module PDF
       sig { params(key: T.untyped).returns(T.untyped) }
       def deref!(key); end
 
-      sig { params(key: T.untyped).returns(T::Array[T.untyped]) }
+      sig { params(key: T.untyped).returns(T.nilable(T::Array[T.untyped])) }
       def deref_array!(key); end
 
-      sig { params(key: T.untyped).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(key: T.untyped).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
       def deref_hash!(key); end
 
       sig { params(key: T.untyped, local_default: T.untyped).returns(T.untyped) }

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -439,8 +439,6 @@ module PDF
     end
 
     class FormXObject
-      include ResourceMethods
-
       sig { returns(T.untyped) }
       attr_reader :xobject
 
@@ -828,8 +826,6 @@ module PDF
     end
 
     class Page
-      include ResourceMethods
-
       sig { returns(PDF::Reader::ObjectHash) }
       attr_reader :objects
 
@@ -1407,31 +1403,36 @@ module PDF
       def series(*methods); end
     end
 
-    module ResourceMethods
-      extend T::Helpers
+    class Resources
 
-      sig { returns(T.untyped) }
+      sig { params(objects: PDF::Reader::ObjectHash, resources: T::Hash[T.untyped, T.untyped]).void }
+      def initialize(objects, resources)
+        @objects = T.let(T.unsafe(nil), PDF::Reader::ObjectHash)
+        @resources = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+      end
+
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def color_spaces; end
 
-      sig { returns(T::Hash[T.untyped, T.untyped]) }
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def fonts; end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def graphic_states; end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def patterns; end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Array[Symbol]) }
       def procedure_sets; end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def properties; end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def shadings; end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Hash[Symbol, PDF::Reader::Stream]) }
       def xobjects; end
     end
 
@@ -1707,8 +1708,14 @@ module PDF
       sig { params(obj: T.untyped).returns(T.nilable(Symbol)) }
       def self.cast_to_symbol(obj); end
 
+      sig { params(obj: T.untyped).returns(Symbol) }
+      def self.cast_to_symbol!(obj); end
+
       sig { params(obj: T.untyped).returns(T::Hash[Symbol, T.untyped]) }
       def self.cast_to_pdf_dict!(obj); end
+
+      sig { params(obj: T.untyped).returns(T::Hash[Symbol, PDF::Reader::Stream]) }
+      def self.cast_to_pdf_dict_with_stream_values!(obj); end
     end
 
     class ValidatingReceiver


### PR DESCRIPTION
in #423 I refactored the resource methods to be handled via a subclass
rather than a mixin. Primarily to make it easier to work with sorbet
type sigs.

Unfortunately I failed to update the rbi file to match, oops. I'm really
not liking the way I need to maintain type sigs in a separate file -
it's super easy for it to get out of sync with the code and sorbet not
to flag it.

This aligns the rbi file with the code again, and tests it works by
removing the T.untyped from the xobjects sig. Code around pdf-reader
assumes the xobject values are a Stream, so we should ensure that's
always true.