### PR TITLE
Font glyph widths must be an array of numbers

### DIFF
--- a/lib/pdf/reader/font.rb
+++ b/lib/pdf/reader/font.rb
@@ -173,7 +173,7 @@ class PDF::Reader
 
       # CID Fonts are not required to have a W or DW entry, if they don't exist,
       # the default cid width = 1000, see Section 9.7.4.1 PDF 32000-1:2008 pp 269
-      @cid_widths         = @ohash.deref_array(obj[:W])  || []
+      @cid_widths         = @ohash.deref_array_of_numbers(obj[:W])  || []
       @cid_default_width  = @ohash.deref_number(obj[:DW]) || 1000
 
       if obj[:ToUnicode]


### PR DESCRIPTION
... so assert that when we read it out of the PDF. This should mean we
catch invalid/corrupt PDFs early and raise a MalformedPDFError, rather
than pass around an Array of god knows what.