### PR TITLE
change PDF::Reader to `typed: strict`

### DIFF
--- a/lib/pdf/reader.rb
+++ b/lib/pdf/reader.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 ################################################################################
@@ -128,7 +128,7 @@ module PDF
       doc_strings_to_utf8(dict)
     end
 
-    # Return a Hash with extra metadata provided by the author of the PDF file. Not
+    # Return a String with extra XML metadata provided by the author of the PDF file. Not
     # always present.
     #
     def metadata
@@ -272,13 +272,7 @@ module PDF
     end
 
     def root
-      @root ||= begin
-        obj = @objects.deref_hash(@objects.trailer[:Root]) || {}
-        unless obj.kind_of?(::Hash)
-          raise MalformedPDFError, "PDF malformed, trailer Root should be a dictionary"
-        end
-        obj
-      end
+      @root ||= @objects.deref_hash(@objects.trailer[:Root]) || {}
     end
 
   end

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -1,16 +1,21 @@
 # typed: strong
 module PDF
   class Reader
-    sig { returns(T.untyped) }
+    sig { returns(PDF::Reader::ObjectHash) }
     attr_reader :objects
 
     sig { params(input: T.any(String, IO), opts: T::Hash[T.untyped, T.untyped]).void }
-    def initialize(input, opts = {}); end
+    def initialize(input, opts = {})
+      @cache = T.let(T.unsafe(nil), PDF::Reader::ObjectCache)
+      @objects = T.let(T.unsafe(nil), PDF::Reader::ObjectHash)
+      @page_count = T.let(T.unsafe(nil), T.nilable(Integer))
+      @root = T.let(T.unsafe(nil), T.nilable(T.nilable(T::Hash[Symbol, T.untyped])))
+    end
 
     sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
     def info; end
 
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(String)) }
     def metadata; end
 
     sig { returns(Integer) }


### PR DESCRIPTION
slowly slowly rolling out strict.

This was a fun one - sorbet pointed out that the type check in root() isn't needed any more - type typed deref_hash() does that for us.