### PR TITLE
Switch PDF::Reader::WidthCalculator::BuiltIn to typed:strict

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 # We require sorbet here rather than in the gemspec so we can avoid loading it in CI
 # for rubies < 2.3
-gem "sorbet", "0.5.9897"
+gem "sorbet", "0.5.10001"
 gem 'parlour'

--- a/auto/run-sorbet
+++ b/auto/run-sorbet
@@ -2,4 +2,6 @@
 #
 # Run the tests
 
-$(dirname $0)/with-ruby srb tc
+# The extra flags to sorbet are a workaround to allow be to declare type hints for constants in the RBI file
+
+$(dirname $0)/with-ruby srb tc --max-threads=1 --stress-incremental-resolver

--- a/lib/pdf/reader/width_calculator/built_in.rb
+++ b/lib/pdf/reader/width_calculator/built_in.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require 'afm'

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -1960,13 +1960,9 @@ module PDF
 
     module WidthCalculator
       class BuiltIn
-        BUILTINS = [
-        :Courier, :"Courier-Bold", :"Courier-BoldOblique", :"Courier-Oblique",
-        :Helvetica, :"Helvetica-Bold", :"Helvetica-BoldOblique", :"Helvetica-Oblique",
-        :Symbol,
-        :"Times-Roman", :"Times-Bold", :"Times-BoldItalic", :"Times-Italic",
-        :ZapfDingbats
-      ]
+        BUILTINS = T.let(T.unsafe(nil), T::Array[Symbol])
+
+        @@all_metrics = T.let(T.unsafe(nil), T.nilable(PDF::Reader::SynchronizedCache))
 
         sig { params(font: PDF::Reader::Font).void }
         def initialize(font)


### PR DESCRIPTION
This required a couple of surprising things for sorbet to be happy with me declaring type hints for a constant in an RBI file:

* update to the latest sorbet
* add some flags to the sorbet command (see [1] and [2])

[1] https://stackoverflow.com/questions/70770441/how-can-i-resolve-sorbet-error-constants-must-have-type-annotations-with-t-let
[2] https://github.com/sorbet/sorbet/issues/5137