### PR TITLE
do most of the work required to set PDF::Reader::XRef to typed:strict

### DIFF
--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -597,10 +597,10 @@ class PDF::Reader
     end
 
     def extract_io_from(input)
-      if input.respond_to?(:seek) && input.respond_to?(:read)
+      if input.is_a?(IO) || input.is_a?(StringIO)
         input
       elsif File.file?(input.to_s)
-        StringIO.new read_as_binary(input)
+        StringIO.new read_as_binary(input.to_s)
       else
         raise ArgumentError, "input must be an IO-like object or a filename"
       end
@@ -610,7 +610,7 @@ class PDF::Reader
       if File.respond_to?(:binread)
         File.binread(input.to_s)
       else
-        File.open(input.to_s,"rb") { |f| f.read }
+        File.open(input.to_s,"rb") { |f| f.read } || ""
       end
     end
 

--- a/lib/pdf/reader/xref.rb
+++ b/lib/pdf/reader/xref.rb
@@ -73,7 +73,7 @@ class PDF::Reader
     #
     # ref - a PDF::Reader::Reference object containing an object ID and revision number
     def [](ref)
-      @xref[ref.id][ref.gen]
+      @xref.fetch(ref.id, {}).fetch(ref.gen)
     rescue
       raise InvalidObjectError, "Object #{ref.id}, Generation #{ref.gen} is invalid"
     end
@@ -82,8 +82,8 @@ class PDF::Reader
     def each(&block)
       ids = @xref.keys.sort
       ids.each do |id|
-        gen = @xref[id].keys.sort[-1]
-        yield PDF::Reader::Reference.new(id, gen)
+        gen = @xref.fetch(id, {}).keys.sort[-1]
+        yield PDF::Reader::Reference.new(id, gen.to_i)
       end
     end
     ################################################################################

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -93,11 +93,11 @@ module PDF
       sig { returns(Integer) }
       attr_reader :pos
 
-      sig { params(io: T.any(StringIO, File), opts: T::Hash[Symbol, T.untyped]).void }
+      sig { params(io: T.any(StringIO, IO), opts: T::Hash[Symbol, T.untyped]).void }
       def initialize(io, opts = {})
         @pos = T.let(T.unsafe(nil), Integer)
         @tokens = T.let(T.unsafe(nil), T::Array[T.any(String, PDF::Reader::Reference)])
-        @io = T.let(T.unsafe(nil), T.any(StringIO, File))
+        @io = T.let(T.unsafe(nil), T.any(StringIO, IO))
         @in_content_stream = T.let(T.unsafe(nil), T::Boolean)
       end
 
@@ -780,10 +780,10 @@ module PDF
       sig { returns(Float) }
       def read_version; end
 
-      sig { params(input: T.untyped).returns(IO) }
+      sig { params(input: T.any(IO, StringIO, String)).returns(T.any(IO, StringIO)) }
       def extract_io_from(input); end
 
-      sig { params(input: T.untyped).returns(T.untyped) }
+      sig { params(input: String).returns(String) }
       def read_as_binary(input); end
     end
 
@@ -1812,12 +1812,18 @@ module PDF
 
     class XRef
       include Enumerable
+      extend T::Generic # Provides `type_member` helper
 
       sig { returns(T.untyped) }
       attr_reader :trailer
 
-      sig { params(io: T.untyped).void }
-      def initialize(io); end
+      sig { params(io: T.any(IO, StringIO)).void }
+      def initialize(io)
+        @io = T.let(T.unsafe(nil), T.any(IO, StringIO))
+        @junk_offset = T.let(T.unsafe(nil), Integer)
+        @xref = T.let(T.unsafe(nil), T::Hash[Integer, T::Hash[Integer, Integer]])
+        @trailer = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+      end
 
       sig { returns(T.untyped) }
       def size; end


### PR DESCRIPTION
There's one remaining blocker, but may as well land this much.

Required standardising on the type we use for IO.