### PR TITLE
Fix typo in documentation of `pages` method

### DIFF
--- a/lib/pdf/reader.rb
+++ b/lib/pdf/reader.rb
@@ -182,7 +182,7 @@ module PDF
     #
     #   reader.pages.each do |page|
     #     puts page.fonts
-    #     puts page.images
+    #     puts page.rectangles
     #     puts page.text
     #   end
     #


### PR DESCRIPTION
It return `PDF::Reader::Page` object, and this object has no
`images` method, but got several other, like `rectangles` for example