### PR TITLE
Fix RangeError (1..0 out of range)

### DIFF
--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -106,7 +106,7 @@ class PDF::Reader
     end
 
     def local_string_insert(haystack, needle, index)
-      haystack[Range.new(index, index + needle.length - 1)] = String.new(needle)
+      haystack[Range.new(index, index + needle.length - 1)] = String.new(needle) if needle.length > 0
     end
 
     def process_mediabox(mediabox)


### PR DESCRIPTION
I have Pdf documents where the needle length is 0 and this generates a RangeError (1..0 out of range) without a check for needle.length > 0