### PR TITLE
Fix assigned but unused variable warnings

### DIFF
--- a/lib/pdf/reader/font.rb
+++ b/lib/pdf/reader/font.rb
@@ -82,8 +82,8 @@ class PDF::Reader
       glyph_width_in_glyph_space = glyph_width(code_point)
 
       if @subtype == :Type3
-        x1, y1 = font_matrix_transform(0,0)
-        x2, y2 = font_matrix_transform(glyph_width_in_glyph_space, 0)
+        x1, _y1 = font_matrix_transform(0,0)
+        x2, _y2 = font_matrix_transform(glyph_width_in_glyph_space, 0)
         (x2 - x1).abs.round(2)
       else
         glyph_width_in_glyph_space / 1000.0


### PR DESCRIPTION
Hello ,

Thanks for this gem, really useful!

I noticed when running an RSpec test suite (with warnings enabled) that requiring this gem generates some noise in the test output like:

```
$GEM_HOME/gems/pdf-reader-2.11.0/lib/pdf/reader/font.rb:85: warning: assigned but unused variable - y1
$GEM_HOME/gems/pdf-reader-2.11.0/lib/pdf/reader/font.rb:86: warning: assigned but unused variable - y2
```

A fairly minor annoyance, but when fixed the test suite in question has no further warnings; just a tranquil sea of green dots 😄