### PR TITLE
Run specs on ruby 3.2 rc1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,6 +83,12 @@ steps:
       RUBY_VERSION: "3.1"
 
   - command: "auto/run-specs"
+    label: "rspec (3.2)"
+    env:
+      DOCKER_IMAGE: "ruby"
+      RUBY_VERSION: "3.2-rc"
+
+  - command: "auto/run-specs"
     label: "rspec (jruby-9.1)"
     env:
       DOCKER_IMAGE: "jruby"


### PR DESCRIPTION
3.2.0 was released yesterday, but there's no docker image yet. This will do for now.