### PR TITLE
Run 3.2 CI on the final 3.2 release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,7 +86,7 @@ steps:
     label: "rspec (3.2)"
     env:
       DOCKER_IMAGE: "ruby"
-      RUBY_VERSION: "3.2-rc"
+      RUBY_VERSION: "3.2"
 
   - command: "auto/run-specs"
     label: "rspec (jruby-9.1)"


### PR DESCRIPTION
A 3.2 final tag has appeared on docker hub