### PR TITLE
bump various CI steps from ruby 2.7 to 3.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,19 +3,19 @@ steps:
     label: ":sorbet:"
     env:
       DOCKER_IMAGE: "ruby"
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "3.1"
 
   - command: "auto/run-require-strict-typing"
     label: "typed: strict"
     env:
       DOCKER_IMAGE: "ruby"
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "3.1"
 
   - command: "auto/run-quality"
     label: "quality"
     env:
       DOCKER_IMAGE: "ruby"
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "3.1"
 
   - wait
 


### PR DESCRIPTION
2.7 is getting pretty old now - technically it left security support a month or two ago.

This probably could've been included in 559b447, but I forget these values existed.