### PR TITLE
Allow StringIO type for PDF::Reader input

### DIFF
--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -4,7 +4,7 @@ module PDF
     sig { returns(PDF::Reader::ObjectHash) }
     attr_reader :objects
 
-    sig { params(input: T.any(String, Tempfile, IO), opts: T::Hash[T.untyped, T.untyped]).void }
+    sig { params(input: T.any(String, Tempfile, IO, StringIO), opts: T::Hash[T.untyped, T.untyped]).void }
     def initialize(input, opts = {})
       @cache = T.let(T.unsafe(nil), PDF::Reader::ObjectCache)
       @objects = T.let(T.unsafe(nil), PDF::Reader::ObjectHash)


### PR DESCRIPTION
It looks like this initializer should accept the StringIO type as mentioned [in this comment](https://github.com/yob/pdf-reader/blob/main/lib/pdf/reader.rb#L102). However, when this is called with a StringIO value, a Sorbet error is raised. 