### PR TITLE
Allow Ascii81 1.0 and 2.0

### DIFF
--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -34,7 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("pry")
   spec.add_development_dependency("rdoc")
 
-  spec.add_dependency('Ascii85', '~> 1.0')
+  # v2.0.0 has some encoding issues with binary data
+  spec.add_dependency('Ascii85', '>= 1.0', '< 3.0', '!= 2.0.0')
   spec.add_dependency('ruby-rc4')
   spec.add_dependency('hashery', '~> 2.0')
   spec.add_dependency('ttfunk')


### PR DESCRIPTION
But not 2.0.0, it has some encoding issues with binary data

https://github.com/DataWraith/ascii85gem/issues/8

Fixes #538