### PR TITLE
Raise the minimum supported ruby to 2.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,6 @@ steps:
       RUBY_VERSION: "{{matrix}}"
       BUNDLE_GEMFILE: "/work/Gemfile-legacy"
     matrix:
-      - "2.0"
       - "2.1"
       - "2.2"
       - "2.3"

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["James Healy"]
   spec.email   = ["james@yob.id.au"]
   spec.homepage = "https://github.com/yob/pdf-reader"
-  spec.required_ruby_version = ">=2.0"
+  spec.required_ruby_version = ">=2.1"
 
   if spec.respond_to?(:metadata)
     spec.metadata = {


### PR DESCRIPTION
Drops support for 2.0, released nearly 12 years ago (2013-02-24).

2.1 was released 11 years ago (2013-12-25), that's a reasonable version to support.