### PR TITLE
Add release steps to the buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,0 +1,18 @@
+agents:
+  queue: hosted
+
+steps:
+  - command: "auto/release-gem"
+    label: ":rubygems:"
+    key: release
+    env:
+      RELEASE_VERSION: "__TEMPLATE__"
+    branches: main
+    plugins:
+      - rubygems-oidc#bashify:
+          role: "rg_oidc_akr_xoy8sqmj25t8ok4rn5sq"
+      - docker#v5.12.0:
+          image: "ruby:3.4-slim"
+          environment:
+            - GEM_HOST_API_KEY
+            - RELEASE_VERSION

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,26 +4,32 @@ agents:
 steps:
   - command: "auto/run-sorbet"
     label: ":sorbet:"
+    key: sorbet
     env:
       DOCKER_IMAGE: "ruby"
       RUBY_VERSION: "3.1"
 
   - command: "auto/run-require-strict-typing"
     label: "typed: strict"
+    key: strict-typing
     env:
       DOCKER_IMAGE: "ruby"
       RUBY_VERSION: "3.1"
 
   - command: "auto/run-quality"
     label: "quality"
+    key: quality
     env:
       DOCKER_IMAGE: "ruby"
       RUBY_VERSION: "3.1"
 
-  - wait
-
   - command: "auto/run-specs"
     label: "rspec ({{matrix}})"
+    key: specs-legacy
+    depends_on:
+      - quality
+      - sorbet
+      - strict-typing
     env:
       DOCKER_IMAGE: "ruby"
       RUBY_VERSION: "{{matrix}}"
@@ -39,6 +45,11 @@ steps:
 
   - command: "auto/run-specs"
     label: "rspec ({{matrix}})"
+    key: specs
+    depends_on:
+      - quality
+      - sorbet
+      - strict-typing
     env:
       DOCKER_IMAGE: "ruby"
       RUBY_VERSION: "{{matrix}}"
@@ -51,6 +62,11 @@ steps:
 
   - command: "auto/run-specs"
     label: "rspec (jruby-{{matrix}})"
+    key: specs-jruby
+    depends_on:
+      - quality
+      - sorbet
+      - strict-typing
     env:
       DOCKER_IMAGE: "jruby"
       RUBY_VERSION: "{{matrix}}"
@@ -62,9 +78,24 @@ steps:
 
   - command: "auto/run-specs"
     label: "rspec (jruby-{{matrix}})"
+    key: specs-jruby-soft
+    depends_on:
+      - quality
+      - sorbet
+      - strict-typing
     env:
       DOCKER_IMAGE: "jruby"
       RUBY_VERSION: "{{matrix}}"
     soft_fail: true
     matrix:
       - "9.4"
+
+  - command: "auto/upload-release-steps"
+    label: "release?"
+    key: upload-release
+    depends_on:
+      - specs
+      - specs-legacy
+      - specs-jruby
+      - specs-jruby-soft
+    branches: main

--- a/auto/release-gem
+++ b/auto/release-gem
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "${GEM_HOST_API_KEY}" ]; then
+  echo "GEM_HOST_API_KEY environment variable not found"
+  exit
+fi
+
+echo "--- Build and publish gem"
+
+cd $(dirname $0)/..
+
+gem build pdf-reader.gemspec
+gem push "pdf-reader-${RELEASE_VERSION}.gem"

--- a/auto/upload-release-steps
+++ b/auto/upload-release-steps
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+#if [ "${BUILDKITE_BRANCH}" != "main" ]; then
+#  echo "Non main branch, skipping release"
+#  exit
+#fi
+
+GEMSPEC_PATH="$(dirname $0)/../pdf-reader.gemspec"
+
+RELEASE_VERSION=$(grep "spec.version =" $GEMSPEC_PATH | sed -r 's/.*spec.version = "([^"]+)".*/\1/')
+
+echo "version: ${RELEASE_VERSION}"
+
+if [ $(curl -s -o /dev/null -w "%{http_code}" https://rubygems.org/api/v2/rubygems/pdf-reader/versions/${RELEASE_VERSION}.json) == "200" ]; then
+  echo "Gem version ${RELEASE_VERSION} already found on rubygems, skipping release"
+  exit
+fi
+
+export RELEASE_VERSION
+
+cat $(dirname $0)/../.buildkite/pipeline.release.yml | sed -r 's/__TEMPLATE__/${RELEASE_VERSION}/' | buildkite-agent pipeline upload

--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -2,7 +2,7 @@
 # which will make the gem filesize irritatingly large
 Gem::Specification.new do |spec|
   spec.name = "pdf-reader"
-  spec.version = "2.13.0"
+  spec.version = "2.14.0"
   spec.summary = "A library for accessing the content of PDF files"
   spec.description = "The PDF::Reader library implements a PDF parser conforming as much as possible to the PDF specification from Adobe"
   spec.license = "MIT"


### PR DESCRIPTION
Noodling on some additional CI steps that will publish to rubygems.org from CI using OIDC, rather than me doing it manually from my laptop.

Partly blocked on https://github.com/rubygems/rubygems.org/issues/5376, which I was able to work around but it makes the setup on rubygems.org difficult.

Hard blocked on https://github.com/rubygems/rubygems.org/pull/5296#issuecomment-2574565891, because rubygems.org recently started requiring OIDC tokens to have a `jti` claim and Buildkite doesn't include it (yet?).

I also switched the pipeline.yml to DAG mode, because it's better.

~I'm not using https://github.com/buildkite-plugins/rubygems-oidc-buildkite-plugin/ because it requires ruby in the CI env and I don't have it (and don't want to jump through hoops to install it)~ I'm now using it, with a branch that converts the plugin to bash