### PR TITLE
Add advanced text run filter for text extraction

### DIFF
--- a/lib/pdf/reader.rb
+++ b/lib/pdf/reader.rb
@@ -280,6 +280,7 @@ end
 ################################################################################
 
 require 'pdf/reader/resources'
+require 'pdf/reader/advanced_text_run_filter'
 require 'pdf/reader/buffer'
 require 'pdf/reader/bounding_rectangle_runs_filter'
 require 'pdf/reader/cid_widths'

--- a/lib/pdf/reader/advanced_text_run_filter.rb
+++ b/lib/pdf/reader/advanced_text_run_filter.rb
@@ -1,0 +1,137 @@
+# coding: utf-8
+# frozen_string_literal: true
+# typed: strict
+
+class PDF::Reader
+  # Filter a collection of TextRun objects based on a set of conditions.
+  # It can be used to filter text runs based on their attributes.
+  # The filter can return the text runs that matches the conditions (only) or
+  # the text runs that do not match the conditions (exclude).
+  #
+  # You can filter the text runs based on all its attributes with the operators
+  # mentioned in VALID_OPERATORS.
+  # The filter can be nested with 'or' and 'and' conditions.
+  #
+  # Examples:
+  # 1. Single condition
+  # AdvancedTextRunFilter.exclude(text_runs, text: { include: 'sample' })
+  #
+  # 2. Multiple conditions (and)
+  # AdvancedTextRunFilter.exclude(text_runs, {
+  #   font_size: { greater_than: 10, less_than: 15 }
+  # })
+  #
+  # 3. Multiple possible values (or)
+  # AdvancedTextRunFilter.exclude(text_runs, {
+  #  font_size: { equal: [10, 12] }
+  # })
+  #
+  # 4. Complex AND/OR filter
+  # AdvancedTextRunFilter.exclude(text_runs, {
+  #   and: [
+  #     { font_size: { greater_than: 10 } },
+  #     { or: [
+  #       { text: { include: "sample" } },
+  #       { width: { greater_than: 100 } }
+  #     ]}
+  #   ]
+  # })
+  class AdvancedTextRunFilter
+    VALID_OPERATORS = %i[
+      equal
+      not_equal
+      greater_than
+      less_than
+      greater_than_or_equal
+      less_than_or_equal
+      include
+      exclude
+    ]
+
+    def self.only(text_runs, filter_hash)
+      new(text_runs, filter_hash).only
+    end
+
+    def self.exclude(text_runs, filter_hash)
+      new(text_runs, filter_hash).exclude
+    end
+
+    attr_reader :text_runs, :filter_hash
+
+    def initialize(text_runs, filter_hash)
+      @text_runs = text_runs
+      @filter_hash = filter_hash
+    end
+
+    def only
+      return text_runs if filter_hash.empty?
+      text_runs.select { |text_run| evaluate_filter(text_run) }
+    end
+
+    def exclude
+      return text_runs if filter_hash.empty?
+      text_runs.reject { |text_run| evaluate_filter(text_run) }
+    end
+
+    private
+
+    def evaluate_filter(text_run)
+      if filter_hash[:or]
+        evaluate_or_filters(text_run, filter_hash[:or])
+      elsif filter_hash[:and]
+        evaluate_and_filters(text_run, filter_hash[:and])
+      else
+        evaluate_filters(text_run, filter_hash)
+      end
+    end
+
+    def evaluate_or_filters(text_run, conditions)
+      conditions.any? do |condition|
+        evaluate_filters(text_run, condition)
+      end
+    end
+
+    def evaluate_and_filters(text_run, conditions)
+      conditions.all? do |condition|
+        evaluate_filters(text_run, condition)
+      end
+    end
+
+    def evaluate_filters(text_run, filter_hash)
+      filter_hash.all? do |attribute, conditions|
+        evaluate_attribute_conditions(text_run, attribute, conditions)
+      end
+    end
+
+    def evaluate_attribute_conditions(text_run, attribute, conditions)
+      conditions.all? do |operator, value|
+        unless VALID_OPERATORS.include?(operator)
+          raise ArgumentError, "Invalid operator: #{operator}"
+        end
+
+        apply_operator(text_run.send(attribute), operator, value)
+      end
+    end
+
+    def apply_operator(attribute_value, operator, filter_value)
+      case operator
+      when :equal
+        Array(filter_value).include?(attribute_value)
+      when :not_equal
+        !Array(filter_value).include?(attribute_value)
+      when :greater_than
+        attribute_value > filter_value
+      when :less_than
+        attribute_value < filter_value
+      when :greater_than_or_equal
+        attribute_value >= filter_value
+      when :less_than_or_equal
+        attribute_value <= filter_value
+      when :include
+        Array(filter_value).any? { |v| attribute_value.to_s.include?(v.to_s) }
+      when :exclude
+        Array(filter_value).none? { |v| attribute_value.to_s.include?(v.to_s) }
+      end
+    end
+  end
+end

--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -68,6 +68,14 @@ module PDF
           runs = merge_runs(runs)
         end
 
+        if (only_filter = opts.fetch(:only, nil))
+          runs = AdvancedTextRunFilter.only(runs, only_filter)
+        end
+
+        if (exclude_filter = opts.fetch(:exclude, nil))
+          runs = AdvancedTextRunFilter.exclude(runs, exclude_filter)
+        end
+
         runs
       end
 

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -851,6 +851,52 @@ module PDF
       def self.exclude_empty_strings(runs); end
     end
 
+    class AdvancedTextRunFilter
+      VALID_OPERATORS = T.let(T::Array[Symbol])
+
+      sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
+      def self.only(text_runs, filter_hash); end
+
+      sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
+      def self.exclude(text_runs, filter_hash); end
+
+      sig { returns(T::Array[TextRun]) }
+      attr_reader :text_runs
+
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      attr_reader :filter_hash
+
+      sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).void }
+      def initialize(text_runs, filter_hash)
+        @text_runs = T.let(T.unsafe(nil), T::Array[TextRun])
+        @filter_hash = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
+      end
+
+      sig { returns(T::Array[TextRun]) }
+      def only; end
+
+      sig { returns(T::Array[TextRun]) }
+      def exclude; end
+
+      sig { params(text_run: TextRun).returns(T::Boolean) }
+      def evaluate_filter(text_run); end
+
+      sig { params(text_run: TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
+      def evaluate_or_filters(text_run, conditions); end
+
+      sig { params(text_run: TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
+      def evaluate_and_filters(text_run, conditions); end
+
+      sig { params(text_run: TextRun, filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      def evaluate_filters(text_run, filter_hash); end
+
+      sig { params(text_run: TextRun, attribute: Symbol, conditions: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      def evaluate_attribute_conditions(text_run, attribute, conditions); end
+
+      sig { params(attribute_value: T.untyped, operator: Symbol, filter_value: T.untyped).returns(T::Boolean) }
+      def apply_operator(attribute_value, operator, filter_value); end
+    end
+
     class EventPoint
       sig { returns(Numeric) }
       attr_reader :x

--- a/spec/advanced_text_run_filter_spec.rb
+++ b/spec/advanced_text_run_filter_spec.rb
@@ -1,0 +1,267 @@
+# typed: false
+# coding: utf-8
+
+describe PDF::Reader::AdvancedTextRunFilter do
+  let(:text_runs) do
+    [
+      PDF::Reader::TextRun.new(0, 0, 100, 12, "sample text"),
+      PDF::Reader::TextRun.new(0, 1, 120, 14, "another text"),
+      PDF::Reader::TextRun.new(2, 1, 80, 10, "sample"),
+      PDF::Reader::TextRun.new(0, 2, 80, 20, "other")
+    ]
+  end
+
+  let(:result_text) { result.map(&:text) }
+
+  describe ".only" do
+    let(:result) { described_class.only(text_runs, filter_hash) }
+
+    context "when empty conditions are provided" do
+      let(:filter_hash) { {} }
+
+      it "returns all text runs" do
+        expect(result_text).to eq(["sample text", "another text", "sample", "other"])
+      end
+    end
+
+    context "when a single condition is provided" do
+      let(:filter_hash) { { text: { include: "sample" } } }
+
+      it "returns text runs matching the condition" do
+        expect(result_text).to eq(["sample text", "sample"])
+      end
+    end
+
+    context "when multiple conditions are provided" do
+      let(:filter_hash) { { font_size: { greater_than: 10, less_than: 15 } } }
+
+      it "returns text runs matching the conditions" do
+        expect(result_text).to eq(["sample text",  "another text"])
+      end
+    end
+
+    context "when or conditions are provided" do
+      let(:filter_hash) { {
+        or: [
+          { text: { include: "sample" } },
+          { width: { greater_than: 100 } }]
+      } }
+
+      it "returns text runs matching the conditions" do
+        expect(result_text).to eq(["sample text", "another text", "sample"])
+      end
+    end
+
+    context "when and conditions are provided" do
+      let(:filter_hash) { {
+        and: [
+          { font_size: { greater_than: 10 } },
+          { text: { include: "sample" } }]
+      } }
+
+      it "returns text runs matching the conditions" do
+        expect(result_text).to eq(["sample text"])
+      end
+    end
+
+    context "when invalid operator is provided" do
+      let(:filter_hash) { { text: { invalid_operator: "sample" } } }
+
+      it "raises error" do
+        expect { result }.to raise_error(ArgumentError, "Invalid operator: invalid_operator")
+      end
+    end
+
+    context "OPERATORS" do
+      context "equal" do
+        let(:filter_hash) { { font_size: { equal: 12 } } }
+
+        it "returns text runs matching the condition" do
+          expect(result_text).to eq(["sample text"])
+        end
+      end
+
+      context "not_equal" do
+        let(:filter_hash) { { font_size: { not_equal: 12 } } }
+
+        it "returns text runs matching the condition" do
+          expect(result_text).to eq(["another text", "sample", "other"])
+        end
+      end
+
+      context "greater_than" do
+        let(:filter_hash) { { font_size: { greater_than: 12 } } }
+
+        it "returns text runs matching the condition" do
+          expect(result_text).to eq(["another text", "other"])
+        end
+      end
+
+      context "less_than" do
+        let(:filter_hash) { { font_size: { less_than: 12 } } }
+
+        it "returns text runs matching the condition" do
+          expect(result_text).to eq(["sample"])
+        end
+      end
+
+      context "greater_than_or_equal" do
+        let(:filter_hash) { { font_size: { greater_than_or_equal: 12 } } }
+
+        it "returns text runs matching the condition" do
+          expect(result_text).to eq(["sample text", "another text", "other"])
+        end
+      end
+
+      context "less_than_or_equal" do
+        let(:filter_hash) { { font_size: { less_than_or_equal: 12 } } }
+
+        it "returns text runs matching the condition" do
+          expect(result_text).to eq(["sample text", "sample"])
+        end
+      end
+
+      context "include" do
+        let(:filter_hash) { { text: { include: "text" } } }
+
+        it "returns text runs matching the condition" do
+          expect(result_text).to eq(["sample text", "another text"])
+        end
+      end
+
+      context "exclude" do
+        let(:filter_hash) { { text: { exclude: "text" } } }
+
+        it "returns text runs matching the condition" do
+          expect(result_text).to eq(["sample", "other"])
+        end
+      end
+    end
+  end
+
+  describe ".exclude" do
+    let(:result) { described_class.exclude(text_runs, filter_hash) }
+
+    context "when empty conditions are provided" do
+      let(:filter_hash) { {} }
+
+      it "returns all text runs" do
+        expect(result_text).to eq(["sample text", "another text", "sample", "other"])
+      end
+    end
+
+    context "when a single condition is provided" do
+      let(:filter_hash) { { text: { include: "sample" } } }
+
+      it "returns text runs not matching the condition" do
+        expect(result_text).to eq(["another text", "other"])
+      end
+    end
+
+    context "when multiple conditions are provided" do
+      let(:filter_hash) { { font_size: { greater_than: 10, less_than: 15 } } }
+
+      it "returns text runs not matching the conditions" do
+        expect(result_text).to eq(["sample", "other"])
+      end
+    end
+
+    context "when or conditions are provided" do
+      let(:filter_hash) { {
+        or: [
+          { text: { include: "sample" } },
+          { width: { greater_than: 100 } }]
+      } }
+
+      it "returns text runs not matching the conditions" do
+        expect(result_text).to eq(["other"])
+      end
+    end
+
+    context "when and conditions are provided" do
+      let(:filter_hash) { {
+        and: [
+          { font_size: { greater_than: 10 } },
+          { text: { include: "sample" } }]
+      } }
+
+      it "returns text runs not matching the conditions" do
+        expect(result_text).to eq(["another text", "sample", "other"])
+      end
+    end
+
+    context "when invalid operator is provided" do
+      let(:filter_hash) { { text: { invalid_operator: "sample" } } }
+
+      it "raises error" do
+        expect { result }.to raise_error(ArgumentError, "Invalid operator: invalid_operator")
+      end
+    end
+
+    context "OPERATORS" do
+      context "equal" do
+        let(:filter_hash) { { font_size: { equal: 12 } } }
+
+        it "returns text runs not matching the condition" do
+          expect(result_text).to eq(["another text", "sample", "other"])
+        end
+      end
+
+      context "not_equal" do
+        let(:filter_hash) { { font_size: { not_equal: 12 } } }
+
+        it "returns text runs not matching the condition" do
+          expect(result_text).to eq(["sample text"])
+        end
+      end
+
+      context "greater_than" do
+        let(:filter_hash) { { font_size: { greater_than: 12 } } }
+
+        it "returns text runs not matching the condition" do
+          expect(result_text).to eq(["sample text", "sample"])
+        end
+      end
+
+      context "less_than" do
+        let(:filter_hash) { { font_size: { less_than: 12 } } }
+
+        it "returns text runs not matching the condition" do
+          expect(result_text).to eq(["sample text", "another text", "other"])
+        end
+      end
+
+      context "greater_than_or_equal" do
+        let(:filter_hash) { { font_size: { greater_than_or_equal: 12 } } }
+
+        it "returns text runs not matching the condition" do
+          expect(result_text).to eq(["sample"])
+        end
+      end
+
+      context "less_than_or_equal" do
+        let(:filter_hash) { { font_size: { less_than_or_equal: 12 } } }
+
+        it "returns text runs not matching the condition" do
+          expect(result_text).to eq(["another text", "other"])
+        end
+      end
+
+      context "include" do
+        let(:filter_hash) { { text: { include: "text" } } }
+
+        it "returns text runs not matching the condition" do
+          expect(result_text).to eq(["sample", "other"])
+        end
+      end
+
+      context "exclude" do
+        let(:filter_hash) { { text: { exclude: "text" } } }
+
+        it "returns text runs not matching the condition" do
+          expect(result_text).to eq(["sample text", "another text"])
+        end
+      end
+    end
+  end
+end

--- a/spec/data/font_sizes.pdf
+++ b/spec/data/font_sizes.pdf
@@ -1,0 +1,94 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Pages 3 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<< /Count 1
+/Kids [5 0 R]
+/Type /Pages
+>>
+endobj
+4 0 obj
+<< /Length 218
+>>
+stream
+q
+
+BT
+36.0 691.38 Td
+/F1.0 90 Tf
+[<42494731>] TJ
+ET
+
+
+BT
+36.0 587.34 Td
+/F1.0 90 Tf
+[<42494732>] TJ
+ET
+
+
+BT
+36.0 539.304 Td
+/F1.0 12 Tf
+[<736d616c6c31>] TJ
+ET
+
+
+BT
+36.0 525.432 Td
+/F1.0 12 Tf
+[<736d616c6c32>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /ArtBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/Contents 4 0 R
+/CropBox [0 0 612 792]
+/MediaBox [0 0 612 792]
+/Parent 3 0 R
+/Resources << /Font << /F1.0 6 0 R
+>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+/TrimBox [0 0 612 792]
+/Type /Page
+>>
+endobj
+6 0 obj
+<< /BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000484 00000 n 
+0000000750 00000 n 
+trailer
+<< /Info 1 0 R
+/Root 2 0 R
+/Size 7
+>>
+startxref
+847
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1781,4 +1781,37 @@ describe PDF::Reader, "integration specs" do
       end
     end
   end
+
+  context "PDF with different font sizes" do
+    let(:filename) { pdf_spec_file("font_sizes") }
+
+    it "extracts font sizes correctly" do
+      PDF::Reader.open(filename) do |reader|
+        text_runs = reader.page(1).runs
+        expect(text_runs.size).to eql(4)
+        expect(text_runs.map(&:font_size)).to eql([90.0, 90.0, 12.0, 12.0])
+      end
+    end
+
+    it "excludes text by font size" do
+      PDF::Reader.open(filename) do |reader|
+        filter = {font_size: {greater_than: 20}}
+        expect(reader.page(1).text(exclude: filter)).to eql("small1\nsmall2")
+      end
+    end
+
+    it "includes only text by font size" do
+      PDF::Reader.open(filename) do |reader|
+        filter = {font_size: {greater_than: 20}}
+        expect(reader.page(1).text(only: filter)).to eql("BIG1\nBIG2")
+      end
+    end
+
+    it "excludes text when including text" do
+      PDF::Reader.open(filename) do |reader|
+        filter = {text: {include: "1"}}
+        expect(reader.page(1).text(exclude: filter)).to eql("BIG2\nsmall2")
+      end
+    end
+  end
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -155,6 +155,9 @@ data/encrypted_version5_revision6_256bit_aes_user_pass_apples_unenc_metadata.pdf
 data/extended_eof.pdf:
   :bytes: 61721
   :md5: 02bd4cfbc79b4a295754fda2705b6181
+data/font_sizes.pdf:
+  :bytes: 1062
+  :md5: c8d4bd87fa2d9b16c9c41501f37905c3
 data/form_xobject.pdf:
   :bytes: 1294
   :md5: db778dde9c16993194dc50f1222b52ab


### PR DESCRIPTION
We are currently stuck on v2.7.0, as later versions break text extraction for us. I finally had some time to investigate this issue.

Our use case involves using the reader to validate generated shipping labels in our tests. These PDFs contain a large "MUSTER" (english "SAMPLE") watermark in the background, which is actually a text element. This watermark appears to confuse the `PageLayout`, which relies on the mean font size to calculate the rows.

As a result:
* The calculated line size is too large, causing some lines to be overwritten by subsequent ones.
* The "MUSTER" watermark appears in the extracted text, where it doesn't belong.

<details>
<summary>Example PDF as image</summary>

![test](https://github.com/user-attachments/assets/b9d131a5-fdb9-42ae-9152-c9370e84a868)
</details>

## The Fix
I implemented a filter to exclude unwanted text during extraction. The filter already supports complex conditions (or, and) and additional operators, which should minimize the risk of future breaking changes and allow more users to customize their parsing.

With this fix, the text can now be read correctly using the following syntax:

```ruby
reader = PDF::Reader.new(...)
page = reader.pages[0]
page.text(exclude: {text: {include: "MUSTER"}})
```
