### PR TITLE
Update sorbet for ARM support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 gemspec
 
 # We require sorbet here rather than in the gemspec so we can avoid loading it in CI
-# for rubies < 2.3
-gem "sorbet", "0.5.10821"
+# for rubies < 2.7
+gem "sorbet", "0.5.11751"
 gem "tapioca", "0.11.6", require: false
 gem 'parlour'
 


### PR DESCRIPTION
I am developing on an ARM Macbook and was not able to install the previous version.

`bundle install` fails with the following message:
```
Could not find gems matching 'sorbet-static (= 0.5.11751)' valid for all resolution platforms (aarch64-linux, universal-darwin, x86_64-linux) in rubygems
repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'sorbet-static (= 0.5.11751)':
  * sorbet-static-0.5.11751-aarch64-linux
  * sorbet-static-0.5.11751-java
  * sorbet-static-0.5.11751-universal-darwin
  * sorbet-static-0.5.11751-x86_64-linux
```

The ARM support was added in a later version of sorbet. I updated it to the latest version.
I haven't found the changelog for sorbet, but haven't experienced issues during #545 either.