### PR TITLE
re-enable strict typing in two files

### DIFF
--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -1,5 +1,5 @@
 # coding: ASCII-8BIT
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 ################################################################################
@@ -52,7 +52,7 @@ class PDF::Reader
     CR = "\r"
     LF = "\n"
     CRLF = "\r\n"
-    WHITE_SPACE = [LF, CR, ' ']
+    WHITE_SPACE = ["\n", "\r", ' ']
 
     # Quite a few PDFs have trailing junk.
     # This can be several k of nuls in some cases

--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 ################################################################################

--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -75,20 +75,20 @@ module PDF
     end
 
     class Buffer
-      TOKEN_WHITESPACE = T.let(T.unsafe(nil), T::Array[Integer])
-      TOKEN_DELIMITER = T.let(T.unsafe(nil), T::Array[Integer])
-      LEFT_PAREN = T.let(T.unsafe(nil), String)
-      LESS_THAN = T.let(T.unsafe(nil), String)
-      STREAM = T.let(T.unsafe(nil), String)
-      ID = T.let(T.unsafe(nil), String)
-      FWD_SLASH = T.let(T.unsafe(nil), String)
-      NULL_BYTE = T.let(T.unsafe(nil), String)
-      CR = T.let(T.unsafe(nil), String)
-      LF = T.let(T.unsafe(nil), String)
-      CRLF = T.let(T.unsafe(nil), String)
-      WHITE_SPACE = T.let(T.unsafe(nil), T::Array[String])
-      TRAILING_BYTECOUNT = T.let(T.unsafe(nil), Integer)
-      DIGITS_ONLY = T.let(T.unsafe(nil), Regexp)
+      TOKEN_WHITESPACE = T.let(T::Array[String])
+      TOKEN_DELIMITER = T.let(T::Array[Integer])
+      LEFT_PAREN = T.let(String)
+      LESS_THAN = T.let(String)
+      STREAM = T.let(String)
+      ID = T.let(String)
+      FWD_SLASH = T.let(String)
+      NULL_BYTE = T.let(String)
+      CR = T.let(String)
+      LF = T.let(String)
+      CRLF = T.let(String)
+      WHITE_SPACE = T.let(T::Array[String])
+      TRAILING_BYTECOUNT = T.let(Integer)
+      DIGITS_ONLY = T.let(Regexp)
 
       sig { returns(Integer) }
       attr_reader :pos


### PR DESCRIPTION
After a recent upgrade to sorbet (#546) I found that I was able to re-enable strict typing here.

It was disabled in #513 because sorbet wasn't finding the type annotation in the rbi file for some constants. It's still inconsistent (for example, I wasn't able to change the cmap.rb back to strict), but these ones are OK.

The constants where sorbet ignores the type definition in the rbi file are all Hashes :thinking: 
