### PR TITLE
Go back to failing the build on jruby 9.4

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,19 +75,6 @@ steps:
       - "9.1"
       - "9.2"
       - "9.3"
-
-  - command: "auto/run-specs"
-    label: "rspec (jruby-{{matrix}})"
-    key: specs-jruby-soft
-    depends_on:
-      - quality
-      - sorbet
-      - strict-typing
-    env:
-      DOCKER_IMAGE: "jruby"
-      RUBY_VERSION: "{{matrix}}"
-    soft_fail: true
-    matrix:
       - "9.4"
 
   - command: "auto/upload-release-steps"
@@ -97,5 +84,4 @@ steps:
       - specs
       - specs-legacy
       - specs-jruby
-      - specs-jruby-soft
     branches: main


### PR DESCRIPTION
Jruby 9.4.11 fixed a bundling issue that was breaking out builds on 9.4.{9,10}.