### PR TITLE
Fix RBI signatures

### DIFF
--- a/rbi/pdf-reader.rbi
+++ b/rbi/pdf-reader.rbi
@@ -854,43 +854,43 @@ module PDF
     class AdvancedTextRunFilter
       VALID_OPERATORS = T.let(T::Array[Symbol])
 
-      sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
+      sig { params(text_runs: T::Array[PDF::Reader::TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[PDF::Reader::TextRun]) }
       def self.only(text_runs, filter_hash); end
 
-      sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
+      sig { params(text_runs: T::Array[PDF::Reader::TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[PDF::Reader::TextRun]) }
       def self.exclude(text_runs, filter_hash); end
 
-      sig { returns(T::Array[TextRun]) }
+      sig { returns(T::Array[PDF::Reader::TextRun]) }
       attr_reader :text_runs
 
       sig { returns(T::Hash[Symbol, T.untyped]) }
       attr_reader :filter_hash
 
-      sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).void }
+      sig { params(text_runs: T::Array[PDF::Reader::TextRun], filter_hash: T::Hash[Symbol, T.untyped]).void }
       def initialize(text_runs, filter_hash)
-        @text_runs = T.let(T.unsafe(nil), T::Array[TextRun])
+        @text_runs = T.let(T.unsafe(nil), T::Array[PDF::Reader::TextRun])
         @filter_hash = T.let(T.unsafe(nil), T::Hash[Symbol, T.untyped])
       end
 
-      sig { returns(T::Array[TextRun]) }
+      sig { returns(T::Array[PDF::Reader::TextRun]) }
       def only; end
 
-      sig { returns(T::Array[TextRun]) }
+      sig { returns(T::Array[PDF::Reader::TextRun]) }
       def exclude; end
 
-      sig { params(text_run: TextRun).returns(T::Boolean) }
+      sig { params(text_run: PDF::Reader::TextRun).returns(T::Boolean) }
       def evaluate_filter(text_run); end
 
-      sig { params(text_run: TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
+      sig { params(text_run: PDF::Reader::TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
       def evaluate_or_filters(text_run, conditions); end
 
-      sig { params(text_run: TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
+      sig { params(text_run: PDF::Reader::TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
       def evaluate_and_filters(text_run, conditions); end
 
-      sig { params(text_run: TextRun, filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      sig { params(text_run: PDF::Reader::TextRun, filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
       def evaluate_filters(text_run, filter_hash); end
 
-      sig { params(text_run: TextRun, attribute: Symbol, conditions: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      sig { params(text_run: PDF::Reader::TextRun, attribute: Symbol, conditions: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
       def evaluate_attribute_conditions(text_run, attribute, conditions); end
 
       sig { params(attribute_value: T.untyped, operator: Symbol, filter_value: T.untyped).returns(T::Boolean) }


### PR DESCRIPTION
The signatures added in #545 do not work when the gem is installed in a Sorbet powered project:

<details>

<summary>Error output</summary>

```
$ bundle exec srb tc
sorbet/rbi/gems/pdf-reader@2.14.0.rbi:260: Unable to resolve constant TextRun https://srb.help/5002
     260 |  sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).void }
                                             ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:260: Replace with PDF::Reader::TextRun
     260 |  sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).void }
                                             ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:264: Unable to resolve constant TextRun https://srb.help/5002
     264 |  sig { returns(T::Array[TextRun]) }
                                   ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:264: Replace with PDF::Reader::TextRun
     264 |  sig { returns(T::Array[TextRun]) }
                                   ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:273: Unable to resolve constant TextRun https://srb.help/5002
     273 |  sig { returns(T::Array[TextRun]) }
                                   ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:273: Replace with PDF::Reader::TextRun
     273 |  sig { returns(T::Array[TextRun]) }
                                   ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:288: Unable to resolve constant TextRun https://srb.help/5002
     288 |  sig { params(text_run: TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
                                   ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:288: Replace with PDF::Reader::TextRun
     288 |  sig { params(text_run: TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
                                   ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:292: Unable to resolve constant TextRun https://srb.help/5002
     292 |  sig { params(text_run: TextRun, attribute: Symbol, conditions: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
                                   ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:292: Replace with PDF::Reader::TextRun
     292 |  sig { params(text_run: TextRun, attribute: Symbol, conditions: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
                                   ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:296: Unable to resolve constant TextRun https://srb.help/5002
     296 |  sig { params(text_run: TextRun).returns(T::Boolean) }
                                   ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:296: Replace with PDF::Reader::TextRun
     296 |  sig { params(text_run: TextRun).returns(T::Boolean) }
                                   ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:300: Unable to resolve constant TextRun https://srb.help/5002
     300 |  sig { params(text_run: TextRun, filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
                                   ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:300: Replace with PDF::Reader::TextRun
     300 |  sig { params(text_run: TextRun, filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
                                   ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:304: Unable to resolve constant TextRun https://srb.help/5002
     304 |  sig { params(text_run: TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
                                   ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:304: Replace with PDF::Reader::TextRun
     304 |  sig { params(text_run: TextRun, conditions: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
                                   ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:309: Unable to resolve constant TextRun https://srb.help/5002
     309 |    sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
                                               ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:309: Replace with PDF::Reader::TextRun
     309 |    sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
                                               ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:309: Unable to resolve constant TextRun https://srb.help/5002
     309 |    sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
                                                                                                                   ^^^^^^^
  Did you mean PDF::Reader::TextRun? Use -a to autocorrect
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:309: Replace with PDF::Reader::TextRun
     309 |    sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
                                                                                                                   ^^^^^^^
    sorbet/rbi/gems/pdf-reader@2.14.0.rbi:3833: PDF::Reader::TextRun defined here
    3833 |class PDF::Reader::TextRun
          ^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:313: Unable to resolve constant TextRun https://srb.help/5002
     313 |    sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
                                               ^^^^^^^

sorbet/rbi/gems/pdf-reader@2.14.0.rbi:313: Unable to resolve constant TextRun https://srb.help/5002
     313 |    sig { params(text_runs: T::Array[TextRun], filter_hash: T::Hash[Symbol, T.untyped]).returns(T::Array[TextRun]) }
                                                                                                                   ^^^^^^^
Errors: 12
```
</details>

This PR fixes the signatures.
