### PR TITLE
Run tests on pre-release of jruby 10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,6 +77,19 @@ steps:
       - "9.3"
       - "9.4"
 
+  - command: "auto/run-specs"
+    label: "rspec (jruby 10)"
+    key: specs-jruby10
+    depends_on:
+      - quality
+      - sorbet
+      - strict-typing
+    soft_fail: true
+    env:
+      DOCKER_IMAGE: "jruby"
+      RUBY_VERSION: "10"
+      BUNDLE_GEMFILE: "/work/Gemfile-legacy"
+
   - command: "auto/upload-release-steps"
     label: "release?"
     key: upload-release

--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -1,0 +1,35 @@
+# From https://github.com/jruby/docker-jruby/blob/ce549508ccf8aeb983f3a4c8bf1f1054d6d60dee/10/jre21/Dockerfile
+FROM eclipse-temurin:21-jre-jammy
+
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV JRUBY_VERSION 10.0.0.0-SNAPSHOT
+ENV JRUBY_SHA256 e71398d3d404c3f2a3b831039a1bf860ec30108dfc22440b4dc1bfe519ac119b
+RUN mkdir /opt/jruby \
+# restore this line once 10 is released
+#  && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
+  && curl -fSL https://oss.sonatype.org/content/repositories/snapshots/org/jruby/jruby-dist/10.0.0.0-SNAPSHOT/jruby-dist-10.0.0.0-20250304.210303-3-bin.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && rm /tmp/jruby.tar.gz \
+  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+       && { \
+               echo 'install: --no-document'; \
+               echo 'update: --no-document'; \
+       } >> /opt/jruby/etc/gemrc
+
+RUN gem install bundler rake net-telnet xmlrpc
+
+# don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_SILENCE_ROOT_WARNING=1 \
+       BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $GEM_HOME/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+
+CMD [ "irb" ]

--- a/auto/with-ruby
+++ b/auto/with-ruby
@@ -9,6 +9,12 @@ ruby_version="${RUBY_VERSION:-3.1}"
 docker_volume_name="pdf-reader-gem-cache-${docker_image}${ruby_version}"
 gemfile="${BUNDLE_GEMFILE:=/work/Gemfile}"
 
+if [ $docker_image = "jruby" ]; then
+  if [ $ruby_version = "10" ]; then
+    docker build -f Dockerfile.jruby -t jruby:10 --load .
+  fi
+fi
+
 docker volume create ${docker_volume_name} > /dev/null
 
 docker run \


### PR DESCRIPTION
There's no jruby:10 image on docker hub yet, but seems like it's a work in progress at https://github.com/jruby/docker-jruby

I grabbed a Dockerfile from there and vendored it for now