### PR TITLE
Fix/Discuss: Broken words, misplaced characters caused by floating point precision issues with font_size

### DIFF
--- a/lib/pdf/reader/page_state.rb
+++ b/lib/pdf/reader/page_state.rb
@@ -118,7 +118,7 @@ class PDF::Reader
         @font_size ||= begin
                          _, zero = trm_transform(0,0)
                          _, one  = trm_transform(1,1)
-                         (zero - one).abs
+                         (zero - one).abs.round(10)
                        end
       end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1423,7 +1423,7 @@ describe PDF::Reader, "integration specs" do
   context "PDF with page rotation of 270 degrees followed by matrix transformations to undo it" do
     let(:filename) { pdf_spec_file("rotate-then-undo") }
     let(:text) {
-      "This page uses matrix transformations to print text   sideways, " +
+      "This page uses matrix transformations to print text sideways, " +
       "then has a Rotate key to fix it"
     }
 
@@ -1634,7 +1634,7 @@ describe PDF::Reader, "integration specs" do
     it "extracts text correctly" do
       PDF::Reader.open(filename) do |reader|
         page = reader.page(1)
-        expect(page.text).to include("This PDF ha  sRotate:90 in the page")
+        expect(page.text).to include("This PDF has Rotate:90 in the page")
         expect(page.text).to include("metadata to get a landscape layout")
         expect(page.text).to include("and text in bottom right quadrant")
       end


### PR DESCRIPTION

- pdf-reader: 2.14.1
- ruby: 3.3.6
- M1 Mac


# Issue:

`page.text` may return text with broken up words, or misplaced characters.

[This PDF will be used for any examples below: Radar.pdf](https://github.com/user-attachments/files/19741960/Radar.pdf)


```ruby
PDF::Reader.new(attached_file).pages[36].text` # This page's text will currently include:
```

`Propaga tion Effects on Ra da r Performance` ❌ 
`Reflection off oearth’s surface` ❌ 

The output should contain:

`Propagation Effects on Radar Performance` ✅ 
`Reflection off of earth’s surface` ✅ 


# Cause:
It appears that floating point precision issues can cause two adjacent TextRun(s) to have a `font_size` which are not `==`. (20.02 vs 20.01999999999999)

This will prevent the [runs from merging](https://github.com/yob/pdf-reader/blob/main/lib/pdf/reader/text_run.rb#L61)

There may be other text rending issues caused by the font_size differences.

Here's a a pry session showing the two different (but the same) font sizes. 

<img width="901" alt="classic_floats" src="https://github.com/user-attachments/assets/0662ff7f-d4a9-4185-a747-10ef5ac6ae2a" />


These two different values are for the "a" and "t" in "Propagation" in the example above ^, leading to the space between them. 

# A possible solution:
Round the calculated value in `PageState#font_size` to some arbitrary precision (In the PR)

## Other solutions
I'm not going to pretend I understand half of what's going on in the pdf parsing and rendering code here. Bearing in mind I have no idea what far reaching effects any change may have:
- Use BigDecimal or some other method to prevent float issues during matrix operations
- Introduce delta checks where font_size is consumed `(size1 - size2).abs <= 0.00001 # instead of == `
- ???

I'm open to other ideas and would be happy to work on other solutions so this issue can be resolved. Otherwise, maybe `.round(...)` is good enough. Let me know.

