### PR TITLE
Allow afm version 1.x.x

### DIFF
--- a/pdf-reader.gemspec
+++ b/pdf-reader.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency('ruby-rc4')
   spec.add_dependency('hashery', '~> 2.0')
   spec.add_dependency('ttfunk')
-  spec.add_dependency('afm', '~> 0.2.1')
+  spec.add_dependency('afm', '>= 0.2.1', '< 2')
 end


### PR DESCRIPTION
Afm release v1.0.0 yesterday: https://rubygems.org/gems/afm

There are no functional changes: https://github.com/halfbyte/afm/blob/main/CHANGELOG.md#100 so pdf-reader should still be compatible.

Full diff: https://github.com/halfbyte/afm/compare/v0.2.2..v1.0.0