### PR TITLE
NO_REF: Fix cypher.final throws error when buffer contains no useful data.

### DIFF
--- a/lib/pdf/reader/aes_v2_security_handler.rb
+++ b/lib/pdf/reader/aes_v2_security_handler.rb
@@ -34,7 +34,10 @@ class PDF::Reader
       cipher.decrypt
       cipher.key = Digest::MD5.digest(objKey)[0,length]
       cipher.iv = buf[0..15]
-      cipher.update(buf[16..-1]) + cipher.final
+      encrypted = buf[16..-1]
+      return '' if encrypted.empty?
+
+      cipher.update(encrypted) + cipher.final
     end
 
   end

--- a/lib/pdf/reader/aes_v3_security_handler.rb
+++ b/lib/pdf/reader/aes_v3_security_handler.rb
@@ -31,7 +31,10 @@ class PDF::Reader
       cipher.decrypt
       cipher.key = @encrypt_key.dup
       cipher.iv = buf[0..15]
-      cipher.update(buf[16..-1]) + cipher.final
+      encrypted = buf[16..-1]
+      return '' if encrypted.empty?
+
+      cipher.update(encrypted) + cipher.final
     end
 
   end


### PR DESCRIPTION
You can reproduce it with simple code:
```
cipher = OpenSSL::Cipher.new('AES-256-CBC')
cipher.key = 'a' * 32
cipher.iv = 'b' * 16
cipher.update("") + cipher.final
```

Page 25 of the attached PDF is the reason I'm trying to fix this.
[278ca303_4340_20250724_120040.pdf](https://github.com/user-attachments/files/21416030/278ca303_4340_20250724_120040.pdf)
