### PR TITLE
Handle PDFs that use AES encryption with no padding

### DIFF
--- a/spec/aes_v3_security_handler_spec.rb
+++ b/spec/aes_v3_security_handler_spec.rb
@@ -71,43 +71,54 @@ describe PDF::Reader::AesV3SecurityHandler do
     end
 
     context "with ciphertext without padding and valid key" do
-      it "should work with no padding when manually encrypted" do
+      it "should decrypt successfully with no padding" do
         plaintext = "1234567890123456" # exactly 16 bytes
         buf = encrypt_test_data(plaintext, key, padding: false)
 
-        # This will likely fail with current implementation since it expects padding
-        # but documents the behavior we want to support
-        expect {
-          handler.decrypt(buf, reference)
-        }.to raise_error(OpenSSL::Cipher::CipherError)
+        result = handler.decrypt(buf, reference)
+        expect(result).to eq(plaintext)
       end
     end
 
     context "with ciphertext without padding and invalid key" do
-      it "raises CipherError when key is wrong" do
+      it "returns incorrect data when key is wrong" do
         wrong_key = "b" * 32 # different 32-byte key
         wrong_handler = PDF::Reader::AesV3SecurityHandler.new(wrong_key)
 
         plaintext = "1234567890123456"
         buf = encrypt_test_data(plaintext, key, padding: false)
 
-        # Try to decrypt with wrong key - should fail
-        expect {
-          wrong_handler.decrypt(buf, reference)
-        }.to raise_error(OpenSSL::Cipher::CipherError)
+        # Try to decrypt with wrong key - should return garbage, not raise error
+        result = wrong_handler.decrypt(buf, reference)
+        expect(result).not_to eq(plaintext)
+        expect(result).to be_a(String)
+      end
+    end
+
+    context "with padded ciphertext and invalid key" do
+      it "returns incorrect data when key is wrong" do
+        wrong_key = "b" * 32 # different 32-byte key
+        wrong_handler = PDF::Reader::AesV3SecurityHandler.new(wrong_key)
+
+        plaintext = "Hello, World!"
+        buf = encrypt_test_data(plaintext, key, padding: true)
+
+        # Try to decrypt with wrong key - should return garbage, not raise error
+        result = wrong_handler.decrypt(buf, reference)
+        expect(result).not_to eq(plaintext)
+        expect(result).to be_a(String)
       end
     end
 
     context "with malformed ciphertext" do
-      it "raises CipherError for corrupted data" do
+      it "returns a string with garbage content" do
         # Create invalid ciphertext with proper 32-byte key handler
         iv = "0123456789abcdef"
         corrupted_data = "corrupted_data16" # exactly 16 bytes
         buf = iv + corrupted_data
 
-        expect {
-          handler.decrypt(buf, reference)
-        }.to raise_error(OpenSSL::Cipher::CipherError)
+        result = handler.decrypt(buf, reference)
+        expect(result).to be_a(String)
       end
     end
   end


### PR DESCRIPTION
From what I can tell this is a non-standard way to use AES encryption, but of course there are PDFs in the wild that do it and other PDF readers seem to handle it.

The two files changing behaviour here are used for:

* encryption v4, revision 4 with 128bit AES encryption
* encryption v5, revsions 5 with 256bit AES encryption

Fixes #534 (sorry this is probably too late to be useful to you @krystof-k)