### PR TITLE
Convert two classes from `typed: true` to `typed: strict`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,10 @@ gemspec
 # for rubies < 2.7
 gem "sorbet", "0.5.12381"
 gem "tapioca", "0.17.7", require: false
-gem "spoom"
+
+# need head of the repo to support parsing type aliases
+# can go back to upstream onec 1.7.6+ released
+gem "spoom", git: "https://github.com/Shopify/spoom.git"
 
 # Required by yard. Part of stdlib in older rubies, but on modern rubies it's a gem
 gem "webrick"

--- a/lib/pdf/reader/cmap.rb
+++ b/lib/pdf/reader/cmap.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 ################################################################################
@@ -51,7 +51,7 @@ class PDF::Reader
 
     #: (String) -> void
     def initialize(data)
-      @map = {}
+      @map = {} #: Hash[Integer, Array[Integer]]
       process_data(data)
     end
 


### PR DESCRIPTION
This wasn't possible before - storing types in an external RBI didn't support precise typing of constants and instance vars. Now we can