### PR TITLE
Avoid infinite recursion when a PDF has a loop in the ancestorsof a Page object

### DIFF
--- a/spec/data/invalid/loop-in-page-ancestors.pdf
+++ b/spec/data/invalid/loop-in-page-ancestors.pdf
@@ -1,0 +1,68 @@
+%PDF-1.7
+
+1 0 obj  % entry point
+<<
+  /Type /Catalog
+  /Pages 2 0 R
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Pages
+  /MediaBox [ 0 0 200 200 ]
+  /Count 1
+  /Kids [ 3 0 R ]
+>>
+endobj
+
+3 0 obj
+<<
+  /Type /Page
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 4 0 R 
+    >>
+  >>
+  /Contents 5 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Type /Font
+  /Subtype /Typå1
+  /BaseFont /Times-Roman
+>>
+endobj
+
+5 0 obj  % page content
+<<
+  /Length 44
+>>
+stream
+BT
+70 50à«D
+/F1 12 Tf
+(Hello, world!) Tj
+ET
+endstream
+endobj
+
+xref
+0 6
+00+0000000 65535 f 
+0000000010 00000 n 
+0000000079 00000 n 
+0000000173 00000 n 
+0000000301 00000 n 
+0000000380 00000 n 
+trailer
+<<
+  /Size 6
+  /Root 1 0 R
+>>
+startxref
+492
+%%EOF

--- a/spec/integration_invalid_spec.rb
+++ b/spec/integration_invalid_spec.rb
@@ -346,6 +346,16 @@ describe PDF::Reader, "integration specs with invalid PDF files" do
     end
   end
 
+  context "loop-in-page-ancestors.pdf" do
+    let(:filename) { pdf_spec_file("loop-in-page-ancestors") }
+
+    it "detects the loop and raises an exception" do
+      expect {
+        parse_pdf(filename)
+      }.to raise_error(PDF::Reader::MalformedPDFError, "loop found in ancestor path")
+    end
+  end
+
   # a very basic sanity check that we can open this file and extract interesting data
   def parse_pdf(filename)
     PDF::Reader.open(filename) do |reader|

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -80,6 +80,9 @@ data/dutch.pdf:
 data/encrypted_and_xref_stream.pdf:
   :bytes: 1197
   :md5: 6bba66a160f820798385a3d1e8e156d2
+data/encrypted_pdf_with_64_chars_string.pdf:
+  :bytes: 13438
+  :md5: 7715b51a0dc346c226a65836b74bc9ab
 data/encrypted_version1_revision2_128bit_rc4_blank_user_password.pdf:
   :bytes: 15674
   :md5: 88a9b78341fa55879fa94930bd4d33af
@@ -245,6 +248,9 @@ data/invalid/invalid_pages.pdf:
 data/invalid/linearized_bad_xref_offset.pdf:
   :bytes: 1133257
   :md5: 245e575d617b8fe69be7e2be382a7730
+data/invalid/loop-in-page-ancestors.pdf:
+  :bytes: 678
+  :md5: 4b30098bc8f935dfbdd4170d40b033c0
 data/invalid/missing_pages_dict.pdf:
   :bytes: 280
   :md5: d2153a115692da4fd5937b1eec842379
@@ -455,6 +461,3 @@ data/zeroed_xref_entry.pdf:
 data/zlib_stream_issue.pdf:
   :bytes: 68247
   :md5: 744d2db962d2aeec04e00891b71b3d5c
-data/encrypted_pdf_with_64_chars_string.pdf:
-  :bytes: 13438
-  :md5: 7715b51a0dc346c226a65836b74bc9ab


### PR DESCRIPTION
Each page in a PDF is a single Object in a tree of Pages->Pages->Page objects, and the page inherits properties from its ancestors right up the tree.

We had not protection against a malicious (or incompetently generated) PDF that built an ancestor tree with a cyclic loop. As a result, attempting to parse such a PDF would raise a SystemStackError when the recursion hit a max depth.

To fix it, when walking up the tree to find all the ancestors keep a record of the ones we have seen and raise an error if we see one again.

Thanks to Yann @ Riema Labs for finding and reporting the issue.