### PR TITLE
Adjust the way CMaps with def operators are handled (592 witrh tweaks)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ desc "Run cane to check quality metrics"
 Cane::RakeTask.new(:quality) do |cane|
   cane.abc_max = 20
   cane.style_measure = 100
-  cane.max_violations = 34
+  cane.max_violations = 32
 
   cane.use Morecane::EncodingCheck, :encoding_glob => "{app,lib,spec}/**/*.rb"
 end

--- a/lib/pdf/reader/cmap.rb
+++ b/lib/pdf/reader/cmap.rb
@@ -81,7 +81,7 @@ class PDF::Reader
       mode = initial_mode
       instructions = []
 
-      while token = parser.parse_token(CMAP_KEYWORDS)
+      while token = parser.parse_token
         if token.is_a?(String) || token.is_a?(Array)
           if token == "beginbfchar"
             mode = :char
@@ -108,7 +108,7 @@ class PDF::Reader
     #: (String) -> PDF::Reader::Parser
     def build_parser(instructions)
       buffer = Buffer.new(StringIO.new(instructions))
-      Parser.new(buffer)
+      Parser.new(buffer, operators: CMAP_KEYWORDS, relaxed_dictionaries: true)
     end
 
     # The following includes some manual decoding of UTF-16BE strings into unicode codepoints. In

--- a/lib/pdf/reader/form_xobject.rb
+++ b/lib/pdf/reader/form_xobject.rb
@@ -103,9 +103,12 @@ module PDF
       def tokens
         @cache[cached_tokens_key] ||= begin
                       buffer = Buffer.new(StringIO.new(raw_content), :content_stream => true)
-                      parser = Parser.new(buffer, @objects)
+                      parser = Parser.new(
+                        buffer,
+                        operators: PagesStrategy::OPERATORS, objects: @objects
+                      )
                       result = []
-                      while (token = parser.parse_token(PagesStrategy::OPERATORS))
+                      while (token = parser.parse_token)
                         result << token
                       end
                       result

--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -558,7 +558,7 @@ class PDF::Reader
     def fetch_object(key)
       if xref[key].is_a?(Integer)
         buf = new_buffer(xref[key])
-        decrypt(key, Parser.new(buf, self).object(key.id, key.gen))
+        decrypt(key, Parser.new(buf, objects: self).object(key.id, key.gen))
       end
     end
 

--- a/lib/pdf/reader/page.rb
+++ b/lib/pdf/reader/page.rb
@@ -274,10 +274,10 @@ module PDF
       #: (Array[untyped], String) -> void
       def content_stream(receivers, instructions)
         buffer       = Buffer.new(StringIO.new(instructions), :content_stream => true)
-        parser       = Parser.new(buffer, @objects)
+        parser       = Parser.new(buffer, operators: PagesStrategy::OPERATORS, objects: @objects)
         params       = []
 
-        while (token = parser.parse_token(PagesStrategy::OPERATORS))
+        while (token = parser.parse_token)
           if token.kind_of?(Token) && method_name = PagesStrategy::OPERATORS[token]
             callback(receivers, method_name, params)
             params.clear

--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -66,6 +66,7 @@ class PDF::Reader
     def initialize(buffer, objects=nil)
       @buffer = buffer
       @objects  = objects
+      @operators = {} #: Hash[String | PDF::Reader::Token, Symbol]
     end
     ################################################################################
     # Reads the next token from the underlying buffer and convets it to an appropriate
@@ -83,6 +84,9 @@ class PDF::Reader
     #|   nil
     #| )
     def parse_token(operators={})
+      # Persist operators so nested calls (dictionary, array) inherit them.
+      # Safe because Parser instances are not reused across parsing contexts.
+      @operators = operators unless operators.empty?
       token = @buffer.token
 
       if token.nil?
@@ -92,7 +96,7 @@ class PDF::Reader
         proc.call(self, token) if proc
       elsif token.is_a? PDF::Reader::Reference
         token
-      elsif operators.has_key? token
+      elsif @operators.has_key? token
         Token.new(token)
       elsif token.frozen?
         token
@@ -152,6 +156,9 @@ class PDF::Reader
       loop do
         key = parse_token
         break if key.kind_of?(Token) and key == ">>"
+        # Skip operator tokens (e.g. PostScript "def") that appear inside
+        # dictionary blocks in CMap streams parsed with operator keywords.
+        next if key.kind_of?(Token)
         raise MalformedPDFError, "unterminated dict" if @buffer.empty?
         PDF::Reader::Error.validate_type_as_malformed(key, "Dictionary key", Symbol)
 
@@ -189,6 +196,9 @@ class PDF::Reader
       loop do
         item = parse_token
         break if item.kind_of?(Token) and item == "]"
+        # Skip operator tokens (e.g. PostScript keywords) that appear inside
+        # array blocks when parsing CMap streams with operator keywords.
+        next if item.kind_of?(Token)
         raise MalformedPDFError, "unterminated array" if @buffer.empty?
         a << item
       end

--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -62,18 +62,27 @@ class PDF::Reader
     #
     # buffer - a PDF::Reader::Buffer object that contains PDF data
     # objects  - a PDF::Reader::ObjectHash object that can return objects from the PDF file
-    #: (PDF::Reader::Buffer, ?PDF::Reader::ObjectHash?) -> void
-    def initialize(buffer, objects=nil)
+    # operators - a hash of supported operators to read from the underlying buffer.
+    # relaxed_dictionaries - quietly skip unexpected operator tokens inside a dictionary. Useful for
+    #                        handling Postscript dictionaries in CMaps
+    #
+    #: (
+    #|   PDF::Reader::Buffer,
+    #|   ?operators: Hash[String | PDF::Reader::Token, Symbol],
+    #|   ?objects: PDF::Reader::ObjectHash?,
+    #|   ?relaxed_dictionaries: T::Boolean
+    #| ) -> void
+    def initialize(buffer, operators: {}, objects: nil, relaxed_dictionaries: false)
       @buffer = buffer
+      @operators = operators
       @objects  = objects
-      @operators = {} #: Hash[String | PDF::Reader::Token, Symbol]
+      @relaxed_dictionaries = relaxed_dictionaries
     end
     ################################################################################
     # Reads the next token from the underlying buffer and convets it to an appropriate
     # object
     #
-    # operators - a hash of supported operators to read from the underlying buffer.
-    #: (?Hash[String | PDF::Reader::Token, Symbol]) -> (
+    #: () -> (
     #|   PDF::Reader::Reference |
     #|   PDF::Reader::Token |
     #|   Numeric |
@@ -83,10 +92,7 @@ class PDF::Reader
     #|   Hash[untyped, untyped] |
     #|   nil
     #| )
-    def parse_token(operators={})
-      # Persist operators so nested calls (dictionary, array) inherit them.
-      # Safe because Parser instances are not reused across parsing contexts.
-      @operators = operators unless operators.empty?
+    def parse_token
       token = @buffer.token
 
       if token.nil?
@@ -156,9 +162,11 @@ class PDF::Reader
       loop do
         key = parse_token
         break if key.kind_of?(Token) and key == ">>"
+
         # Skip operator tokens (e.g. PostScript "def") that appear inside
         # dictionary blocks in CMap streams parsed with operator keywords.
-        next if key.kind_of?(Token)
+        next if @relaxed_dictionaries && key.kind_of?(Token)
+
         raise MalformedPDFError, "unterminated dict" if @buffer.empty?
         PDF::Reader::Error.validate_type_as_malformed(key, "Dictionary key", Symbol)
 
@@ -196,9 +204,6 @@ class PDF::Reader
       loop do
         item = parse_token
         break if item.kind_of?(Token) and item == "]"
-        # Skip operator tokens (e.g. PostScript keywords) that appear inside
-        # array blocks when parsing CMap streams with operator keywords.
-        next if item.kind_of?(Token)
         raise MalformedPDFError, "unterminated array" if @buffer.empty?
         a << item
       end

--- a/spec/data/postscript_cmap_test.pdf
+++ b/spec/data/postscript_cmap_test.pdf
@@ -1,0 +1,67 @@
+%PDF-1.4
+%¥±ë
+
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 612 792] >>
+endobj
+
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding << /Type /Encoding /BaseEncoding /WinAnsiEncoding /Differences [1 /A /B /C] >> /ToUnicode 6 0 R >>
+endobj
+
+5 0 obj
+<< /Length 38 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+<010203> Tj
+ET
+endstream
+endobj
+
+6 0 obj
+<< /Length 366 >>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (TestFont+0) def /Ordering (T1UV) def /Supplement 0 def >> def
+/CMapName /TestFont+0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+3 beginbfchar
+<01> <0041>
+<02> <0042>
+<03> <0043>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end end
+endstream
+endobj
+
+xref
+0 7
+0000000000 65535 f 
+0000000018 00000 n 
+0000000068 00000 n 
+0000000150 00000 n 
+0000000253 00000 n 
+0000000430 00000 n 
+0000000519 00000 n 
+trailer
+<< /Root 1 0 R /Size 7 >>
+startxref
+936
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1868,4 +1868,15 @@ describe PDF::Reader, "integration specs" do
       end
     end
   end
+
+  context "PDF with PostScript-style CMap fonts containing def keywords in dictionaries" do
+    let(:filename) { pdf_spec_file("postscript_cmap_test") }
+
+    it "extracts text correctly" do
+      PDF::Reader.open(filename) do |reader|
+        text = reader.pages.first.text
+        expect(text).to include("ABC")
+      end
+    end
+  end
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -8,6 +8,9 @@ data/TJ_and_char_spacing.pdf:
 data/TJ_starts_with_a_number.pdf:
   :bytes: 13119
   :md5: 83501b5c507cdddbd9283ad2003c885b
+data/actual_text_marked_content.pdf:
+  :bytes: 6651
+  :md5: 3fa1e5422adb93486eaad8a75bd3323c
 data/adobe_sample.pdf:
   :bytes: 378345
   :md5: 07ab19345bfd5d22af6301a5751f94c2
@@ -125,15 +128,9 @@ data/encrypted_version5_revision6_256bit_aes_user_pass_apples_unenc_metadata.pdf
 data/extended_eof.pdf:
   :bytes: 61721
   :md5: 02bd4cfbc79b4a295754fda2705b6181
-data/actual_text_marked_content.pdf:
-  :bytes: 6651
-  :md5: 3fa1e5422adb93486eaad8a75bd3323c
 data/font_sizes.pdf:
   :bytes: 1062
   :md5: c8d4bd87fa2d9b16c9c41501f37905c3
-data/free_object_1_in_xref.pdf:
-  :bytes: 360
-  :md5: ff6b05be75527ec88cb2efeec79cf8cc
 data/form_xobject.pdf:
   :bytes: 1294
   :md5: db778dde9c16993194dc50f1222b52ab
@@ -143,6 +140,9 @@ data/form_xobject_more.pdf:
 data/form_xobject_recursive.pdf:
   :bytes: 1454
   :md5: 24cbbe4f91c23b37f9a1ddac81bd3a39
+data/free_object_1_in_xref.pdf:
+  :bytes: 360
+  :md5: ff6b05be75527ec88cb2efeec79cf8cc
 data/hard_lock_under_osx.pdf:
   :bytes: 4545
   :md5: 365e2076036b5e2445d1dcde13d6dbb6
@@ -371,6 +371,9 @@ data/pdfwriter-manual.pdf:
 data/portrait.pdf:
   :bytes: 288466
   :md5: dc2413fb949ee78fc1e2319ca4ffcd93
+data/postscript_cmap_test.pdf:
+  :bytes: 1139
+  :md5: 8d6a8a24d0ca2d7cef40c401ef0e33ed
 data/prev0.pdf:
   :bytes: 753
   :md5: 5c729e47a5bd097d312df70f913c6349

--- a/spec/reader/cmap_spec.rb
+++ b/spec/reader/cmap_spec.rb
@@ -228,6 +228,33 @@ describe PDF::Reader::CMap do
       end
     end
 
+    context "cmap with PostScript def keywords inside dictionary blocks" do
+      it "correctly loads character mapping" do
+        cmap_data = <<-CMAP
+          /CIDInit /ProcSet findresource begin
+          12 dict begin
+          begincmap
+          /CIDSystemInfo << /Registry (TestFont+0) def /Ordering (T1UV) def /Supplement 0 def >> def
+          /CMapName /TestFont+0 def
+          1 begincodespacerange
+          <00> <FF>
+          endcodespacerange
+          3 beginbfchar
+          <01> <0041>
+          <02> <0042>
+          <03> <0043>
+          endbfchar
+          endcmap
+        CMAP
+
+        map = PDF::Reader::CMap.new(cmap_data)
+        expect(map.size).to eq(3)
+        expect(map.decode(0x01)).to eq([0x0041])
+        expect(map.decode(0x02)).to eq([0x0042])
+        expect(map.decode(0x03)).to eq([0x0043])
+      end
+    end
+
     describe "initialized with an empty string" do
       it "inits without error but has no mappings and decode returns empty arrays" do
         map = PDF::Reader::CMap.new("")

--- a/spec/reader/parser_spec.rb
+++ b/spec/reader/parser_spec.rb
@@ -223,6 +223,21 @@ describe PDF::Reader::Parser do
     end
   end
 
+  it "parses dictionary containing PostScript operators when operators are set" do
+    str = "<< /Registry (Adobe) def /Ordering (UCS) def /Supplement 0 def >>"
+    buf = PDF::Reader::Buffer.new(StringIO.new(str))
+    parser = PDF::Reader::Parser.new(buf)
+    dict = parser.parse_token({"def" => :noop})
+    expect(dict).to eq({Registry: "Adobe", Ordering: "UCS", Supplement: 0})
+  end
+
+  it "raises error for dictionary containing def when no operators are set" do
+    str = "<< /Registry (Adobe) def >>"
+    expect {
+      parse_string(str).parse_token
+    }.to raise_error(PDF::Reader::MalformedPDFError)
+  end
+
   it "parses numbers correctly" do
     parser = parse_string("1 2 -3 4.5 -5")
     expect(parser.parse_token).to eql( 1)

--- a/spec/reader/parser_spec.rb
+++ b/spec/reader/parser_spec.rb
@@ -7,7 +7,9 @@ describe PDF::Reader::Parser do
 
   it "parses a name correctly" do
     expect(parse_string("/James").parse_token).to eql(:James)
-    expect(parse_string("/A;Name_With-Various***Characters?").parse_token).to eql(:"A;Name_With-Various***Characters?")
+    expect(parse_string("/A;Name_With-Various***Characters?").parse_token).to eql(
+      :"A;Name_With-Various***Characters?"
+    )
     expect(parse_string("/1.2").parse_token).to eql(:"1.2")
     expect(parse_string("/$$").parse_token).to eql(:"$$")
     expect(parse_string("/@pattern").parse_token).to eql(:"@pattern")
@@ -119,7 +121,13 @@ describe PDF::Reader::Parser do
       expect(parse_string(src).parse_token).to eql(exp)
     end
 
-    mixed = [ seq[:straddle_seq_5c6e], seq[:char_5c08], seq[:char_5c0a], seq[:char_5c02], seq[:char_contain_0a] ]
+    mixed = [
+      seq[:straddle_seq_5c6e],
+      seq[:char_5c08],
+      seq[:char_5c0a],
+      seq[:char_5c02],
+      seq[:char_contain_0a]
+    ]
     mixed_src = binary_string("(" + bom + mixed.map {|x| x[0]}.join + ")")
     mixed_exp = binary_string(bom + mixed.map {|x| x[1]}.join)
     expect(parse_string(mixed_src).parse_token).to eql(mixed_exp)
@@ -223,12 +231,14 @@ describe PDF::Reader::Parser do
     end
   end
 
-  it "parses dictionary containing PostScript operators when operators are set" do
-    str = "<< /Registry (Adobe) def /Ordering (UCS) def /Supplement 0 def >>"
-    buf = PDF::Reader::Buffer.new(StringIO.new(str))
-    parser = PDF::Reader::Parser.new(buf)
-    dict = parser.parse_token({"def" => :noop})
-    expect(dict).to eq({Registry: "Adobe", Ordering: "UCS", Supplement: 0})
+  context "operators are set and relaxed dictionaries is true" do
+    it "parses dictionary containing PostScript operators" do
+      str = "<< /Registry (Adobe) def /Ordering (UCS) def /Supplement 0 def >>"
+      buf = PDF::Reader::Buffer.new(StringIO.new(str))
+      parser = PDF::Reader::Parser.new(buf, operators: {"def" => :noop}, relaxed_dictionaries: true)
+      dict = parser.parse_token
+      expect(dict).to eq({Registry: "Adobe", Ordering: "UCS", Supplement: 0})
+    end
   end
 
   it "raises error for dictionary containing def when no operators are set" do

--- a/spec/support/parser_helper.rb
+++ b/spec/support/parser_helper.rb
@@ -4,6 +4,6 @@
 module ParserHelper
   def parse_string(r)
     buf = PDF::Reader::Buffer.new(StringIO.new(r))
-    PDF::Reader::Parser.new(buf, nil)
+    PDF::Reader::Parser.new(buf, operators: {})
   end
 end


### PR DESCRIPTION
In #592 a fix for handing CMap parsing was provided. It works well and the new test coverage was excellent, but on style grounds I wanted to tweak the solution a bit.

I'd prefer not to give Parser an API that introduces temporal coupling. That is, the behaviour of the class will vary depending on the order of method calls if one of the methods is `parse_token()` with operators provided.

Parser is an internal class so we can make API changes to it. If we instead provide the operators and a flag to enable "relaxed" dictionary parsing to the constructor then each parser instance will behave consistently. Regardless of the order of method calls.

I also removed the relaxed parsing of Arrays introduced in https://github.com/yob/pdf-reader/pull/592. It's not yet
clear that's needed to parse postscript CMaps. At least, it's not needed for the test file we have.

Finally, I fixed a few long lines while I was in their vicinity, so the cane max_violations has reduced.