### PR TITLE
Reduce object allocations in PDF::Reader::Buffer

### DIFF
--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -392,54 +392,66 @@ class PDF::Reader
           end
         when *TOKEN_WHITESPACE
           # white space, token finished
-          @tokens << tok if tok.size > 0
-
-          #If the token was empty, chomp the rest of the whitespace too
-          while TOKEN_WHITESPACE.include?(peek_byte) && tok.size == 0
-            @io.getbyte
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          else
+            #If the token was empty, chomp the rest of the whitespace too
+            while TOKEN_WHITESPACE.include?(peek_byte)
+              @io.getbyte
+            end
           end
-          tok = "".dup
           break
         when 0x3C
           # opening delimiter '<', start of new token
-          @tokens << tok if tok.size > 0
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
           if peek_byte == 0x3C # check if token is actually '<<'
             @io.getbyte
             @tokens << "<<"
           else
             @tokens << "<"
           end
-          tok = "".dup
           break
         when 0x3E
           # closing delimiter '>', start of new token
-          @tokens << tok if tok.size > 0
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
           if peek_byte == 0x3E # check if token is actually '>>'
             @io.getbyte
             @tokens << ">>"
           else
             @tokens << ">"
           end
-          tok = "".dup
           break
         when 0x28, 0x5B, 0x7B
           # opening delimiter, start of new token
-          @tokens << tok if tok.size > 0
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
           @tokens << byte.chr
-          tok = "".dup
           break
         when 0x29, 0x5D, 0x7D
           # closing delimiter
-          @tokens << tok if tok.size > 0
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
           @tokens << byte.chr
-          tok = "".dup
           break
         when 0x2F
           # PDF name, start of new token
-          @tokens << tok if tok.size > 0
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
           @tokens << byte.chr
           @tokens << "" if byte == 0x2F && ([nil, 0x20, 0x0A] + TOKEN_DELIMITER).include?(peek_byte)
-          tok = "".dup
           break
         else
           tok << byte

--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -428,21 +428,53 @@ class PDF::Reader
             @tokens << ">"
           end
           break
-        when 0x28, 0x5B, 0x7B
-          # opening delimiter, start of new token
+        when 0x28
+          # opening delimiter '(', start of new token
           if tok.size > 0
             @tokens << tok
             tok = "".dup
           end
-          @tokens << byte.chr
+          @tokens << "("
           break
-        when 0x29, 0x5D, 0x7D
-          # closing delimiter
+        when 0x5B
+          # opening delimiter '[', start of new token
           if tok.size > 0
             @tokens << tok
             tok = "".dup
           end
-          @tokens << byte.chr
+          @tokens << "["
+          break
+        when 0x7B
+          # opening delimiter '{', start of new token
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
+          @tokens << "{"
+          break
+        when 0x29
+          # closing delimiter ')'
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
+          @tokens << ")"
+          break
+        when 0x5D
+          # closing delimiter ']'
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
+          @tokens << "]"
+          break
+        when 0x7D
+          # closing delimiter '}'
+          if tok.size > 0
+            @tokens << tok
+            tok = "".dup
+          end
+          @tokens << "}"
           break
         when 0x2F
           # PDF name, start of new token
@@ -450,8 +482,8 @@ class PDF::Reader
             @tokens << tok
             tok = "".dup
           end
-          @tokens << byte.chr
-          @tokens << "" if byte == 0x2F && ([nil, 0x20, 0x0A] + TOKEN_DELIMITER).include?(peek_byte)
+          @tokens << "/"
+          @tokens << "" if ([nil, 0x20, 0x0A] + TOKEN_DELIMITER).include?(peek_byte)
           break
         else
           tok << byte

--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -330,8 +330,12 @@ class PDF::Reader
           # ignore it
         else
           @tokens << str if str.size > 0
-          @tokens << ">" if byte != 0x3E # '>'
-          @tokens << byte.chr
+          if byte == 0x3E
+            @tokens << ">"
+          else
+            @tokens << ">"
+            @tokens << byte.chr
+          end
           break
         end
       end

--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -255,7 +255,7 @@ class PDF::Reader
 
       token_one = @tokens[0]
       token_two = @tokens[1]
-      if token_one.is_a?(String) && token_two.is_a?(String) && token_one.match(DIGITS_ONLY) && token_two.match(DIGITS_ONLY)
+      if token_one.is_a?(String) && token_two.is_a?(String) && token_one.match?(DIGITS_ONLY) && token_two.match?(DIGITS_ONLY)
         @tokens[0] = PDF::Reader::Reference.new(token_one.to_i, token_two.to_i)
         @tokens.delete_at(2)
         @tokens.delete_at(1)

--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -258,10 +258,22 @@ class PDF::Reader
 
       token_one = @tokens[0]
       token_two = @tokens[1]
-      if token_one.is_a?(String) && token_two.is_a?(String) && token_one.match?(DIGITS_ONLY) && token_two.match?(DIGITS_ONLY)
+      if token_one.is_a?(String) && token_two.is_a?(String) && match?(token_one, DIGITS_ONLY) && match?(token_two, DIGITS_ONLY)
         @tokens[0] = PDF::Reader::Reference.new(token_one.to_i, token_two.to_i)
         @tokens.delete_at(2)
         @tokens.delete_at(1)
+      end
+    end
+
+    # Once min ruby version is >= 2.4, we can drop this method and just use String#match?
+    #
+    #: (String, Regexp) -> bool
+    def match?(str, regexp)
+      # We prefer match? because fewer objects are allocated, and this code path is hot
+      if str.respond_to?(:match?)
+        str.match?(regexp)
+      else
+        str.match(regexp) != nil
       end
     end
 

--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -62,6 +62,9 @@ class PDF::Reader
     # must match whole tokens
     DIGITS_ONLY = %r{\A\d+\z} #: Regexp
 
+    # bytes that terminate a PDF name token (used in prepare_regular_token)
+    NAME_TERMINATOR_BYTES = ([nil, 0x20, 0x0A] + TOKEN_DELIMITER).freeze #: Array[Integer?]
+
     #: Integer
     attr_reader :pos
 
@@ -474,7 +477,7 @@ class PDF::Reader
             @tokens << tok
           end
           @tokens << "/"
-          @tokens << "" if ([nil, 0x20, 0x0A] + TOKEN_DELIMITER).include?(peek_byte)
+          @tokens << "" if NAME_TERMINATOR_BYTES.include?(peek_byte)
           break
         else
           tok << byte

--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -383,6 +383,7 @@ class PDF::Reader
 
         case byte
         when nil
+          @tokens << tok if tok.size > 0
           break
         when 0x25
           # comment, ignore everything until the next EOL char
@@ -394,7 +395,6 @@ class PDF::Reader
           # white space, token finished
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           else
             #If the token was empty, chomp the rest of the whitespace too
             while TOKEN_WHITESPACE.include?(peek_byte)
@@ -406,7 +406,6 @@ class PDF::Reader
           # opening delimiter '<', start of new token
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           if peek_byte == 0x3C # check if token is actually '<<'
             @io.getbyte
@@ -419,7 +418,6 @@ class PDF::Reader
           # closing delimiter '>', start of new token
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           if peek_byte == 0x3E # check if token is actually '>>'
             @io.getbyte
@@ -432,7 +430,6 @@ class PDF::Reader
           # opening delimiter '(', start of new token
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           @tokens << "("
           break
@@ -440,7 +437,6 @@ class PDF::Reader
           # opening delimiter '[', start of new token
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           @tokens << "["
           break
@@ -448,7 +444,6 @@ class PDF::Reader
           # opening delimiter '{', start of new token
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           @tokens << "{"
           break
@@ -456,7 +451,6 @@ class PDF::Reader
           # closing delimiter ')'
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           @tokens << ")"
           break
@@ -464,7 +458,6 @@ class PDF::Reader
           # closing delimiter ']'
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           @tokens << "]"
           break
@@ -472,7 +465,6 @@ class PDF::Reader
           # closing delimiter '}'
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           @tokens << "}"
           break
@@ -480,7 +472,6 @@ class PDF::Reader
           # PDF name, start of new token
           if tok.size > 0
             @tokens << tok
-            tok = "".dup
           end
           @tokens << "/"
           @tokens << "" if ([nil, 0x20, 0x0A] + TOKEN_DELIMITER).include?(peek_byte)
@@ -489,8 +480,6 @@ class PDF::Reader
           tok << byte
         end
       end
-
-      @tokens << tok if tok.size > 0
     end
 
     # peek at the next character in the io stream, leaving the stream position

--- a/lib/pdf/reader/buffer.rb
+++ b/lib/pdf/reader/buffer.rb
@@ -398,7 +398,7 @@ class PDF::Reader
             commentbyte = @io.getbyte
             break if commentbyte.nil? || commentbyte == 0x0A || commentbyte == 0x0D
           end
-        when *TOKEN_WHITESPACE
+        when 0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20 # TOKEN_WHITESPACE
           # white space, token finished
           if tok.size > 0
             @tokens << tok


### PR DESCRIPTION
A variety of tweaks to this class to make it allocate fewer objects. The difference is significant, the below benchmarks were run on MRI 3.4.9:

* `cairo-unicode.pdf`: 486k -> 326k allocations (~32% reduction)
* `pdflatex.pdf`: 936K -> 744K allocations (~20%)
* `prince1.pdf`: 162k -> 74K allocations (~54%)
 
## Before

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    31.213M memsize (     0.000  retained)
                       486.368k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.571M memsize (     1.018M retained)
                        67.102k objects (    13.994k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   485.511k memsize (     0.000  retained)
                         6.797k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter     1.385M memsize (     0.000  retained)
                        19.802k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1    13.311M memsize (     0.000  retained)
                       162.829k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    61.406M memsize (     0.000  retained)
                       936.947k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
````

## After

```
$ ruby -I lib scripts/benchmark_allocations.rb                                                                                       
Calculating -------------------------------------                                         
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf                           
       cairo-unicode    20.418M memsize (     0.000  retained)                            
                       326.706k objects (     0.000  retained)                            
                        50.000  strings (     0.000  retained)                            
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf                             
         type1-arial     4.476M memsize (     1.018M retained)                            
                        65.780k objects (    13.994k retained)                            
                        50.000  strings (    50.000  retained)                            
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf                          
      truetype-arial   380.879k memsize (     0.000  retained)                            
                         5.328k objects (     0.000  retained)                            
                        50.000  strings (     0.000  retained)                            
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf                          
      ascii85_filter   994.509k memsize (     0.000  retained)                            
                        14.335k objects (     0.000  retained)                            
                        50.000  strings (     0.000  retained)                            
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf                                 
             prince1     6.690M memsize (     0.000  retained)                            
                        74.270k objects (     0.000  retained)                            
                        50.000  strings (     0.000  retained)                            
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf                                
            pdflatex    48.066M memsize (     0.000  retained)                            
                       744.293k objects (     0.000  retained)                            
                        50.000  strings (     0.000  retained)
```

