### PR TITLE
Reduce object allocations in PDF::Reader::Parser

### DIFF
--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -196,9 +196,11 @@ class PDF::Reader
       tok = @buffer.token
 
       if tok.is_a?(String)
-        tok = tok.dup.gsub(/#([A-Fa-f0-9]{2})/) do |match|
-          res = match[1, 2]
-          res ? res.hex.chr : ""
+        if tok.include?('#')
+          tok = tok.gsub(/#([A-Fa-f0-9]{2})/) do |match|
+            res = match[1, 2]
+            res ? res.hex.chr : ""
+          end
         end
         tok.to_sym
       elsif tok.is_a?(PDF::Reader::Reference)

--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -77,6 +77,7 @@ class PDF::Reader
       @operators = operators
       @objects  = objects
       @relaxed_dictionaries = relaxed_dictionaries
+      @hex_pack_buffer = [""] #: Array[String]
     end
     ################################################################################
     # Reads the next token from the underlying buffer and convets it to an appropriate
@@ -228,18 +229,21 @@ class PDF::Reader
     # Reads a PDF hex string from the buffer and converts it to a Ruby String
     #: () -> String
     def hex_string
-      str = "".dup
+      str = @buffer.token
 
-      loop do
-        token = @buffer.token
-        break if token == ">"
-        raise MalformedPDFError, "unterminated hex string" if @buffer.empty?
-        str << token
+      if str == ">"
+        # empty hex string
+        return "".dup.force_encoding("binary")
       end
+
+      raise MalformedPDFError, "unterminated hex string" if str.nil? || @buffer.empty?
+      raise MalformedPDFError, "invalid hex string" unless str.is_a?(String)
+      @buffer.token # consume the closing ">"
 
       # add a missing digit if required, as required by the spec
       str << "0" unless str.size % 2 == 0
-      [str].pack('H*')
+      @hex_pack_buffer[0] = str
+      @hex_pack_buffer.pack('H*')
     end
     ################################################################################
     # Reads a PDF String from the buffer and converts it to a Ruby String

--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -106,7 +106,7 @@ class PDF::Reader
         Token.new(token)
       elsif token.frozen?
         token
-      elsif token =~ /\d*\.\d/
+      elsif match?(token, /\d*\.\d/)
         token.to_f
       else
         token.to_i
@@ -152,6 +152,18 @@ class PDF::Reader
     end
 
     private
+
+    # Once min ruby version is >= 2.4, we can drop this method and just use String#match?
+    #
+    #: (String, Regexp) -> bool
+    def match?(str, regexp)
+      # We prefer match? because fewer objects are allocated, and this code path is hot
+      if str.respond_to?(:match?)
+        str.match?(regexp)
+      else
+        str.match(regexp) != nil
+      end
+    end
 
     ################################################################################
     # reads a PDF dict from the buffer and converts it to a Ruby Hash.


### PR DESCRIPTION
A variety of tweaks to this class to allocate fewer objects. The difference is modest, mostly depending on how much the PDF uses hex strings and names with `#xx` format. The below benchmarks were run on MRI 3.4.9:

* `cairo-unicode.pdf`: 326k -> 305k allocations (~6% reduction)
* `pdflatex.pdf`: 744K -> 731K allocations (~1.7% reduction)
* `prince1.pdf`: 74k -> 59K allocations (~20% reduction)
 
## Before

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    20.417M memsize (     0.000  retained)
                       326.680k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.476M memsize (     1.018M retained)
                        65.788k objects (    13.994k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   381.199k memsize (     0.000  retained)
                         5.336k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   994.509k memsize (     0.000  retained)
                        14.335k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     6.690M memsize (     0.000  retained)
                        74.270k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    48.067M memsize (     0.000  retained)
                       744.305k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
````

## After

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    18.955M memsize (     0.000  retained)
                       305.060k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.471M memsize (     1.018M retained)
                        65.684k objects (    13.994k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   373.871k memsize (     0.000  retained)
                         5.216k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   970.205k memsize (     0.000  retained)
                        14.009k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     5.159M memsize (     0.000  retained)
                        59.354k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    46.900M memsize (     0.000  retained)
                       731.675k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```

