### PR TITLE
Reduce object allocations in various text extraction related code

### DIFF
--- a/lib/pdf/reader/bounding_rectangle_runs_filter.rb
+++ b/lib/pdf/reader/bounding_rectangle_runs_filter.rb
@@ -10,7 +10,7 @@ class PDF::Reader
 
     #: (Array[PDF::Reader::TextRun], PDF::Reader::Rectangle) -> Array[PDF::Reader::TextRun]
     def self.runs_within_rect(runs, rect)
-      runs.select { |run| rect.contains?(run.origin) }
+      runs.select { |run| rect.contains_xy?(run.x, run.y) }
     end
   end
 end

--- a/lib/pdf/reader/cmap.rb
+++ b/lib/pdf/reader/cmap.rb
@@ -50,6 +50,8 @@ class PDF::Reader
     # https://en.wikipedia.org/wiki/Universal_Character_Set_characters
     HIGH_SURROGATE_RANGE = (0xD800..0xDBFF) #: Range[Integer]
 
+    EMPTY_CODEPOINTS = [].freeze #: Array[Integer]
+
     #: Hash[Integer, Array[Integer]]
     attr_reader :map
 
@@ -70,7 +72,7 @@ class PDF::Reader
     #
     #: (Integer) -> Array[Integer]
     def decode(c)
-      @map.fetch(c, [])
+      @map.fetch(c, EMPTY_CODEPOINTS)
     end
 
     private

--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -222,8 +222,9 @@ class PDF::Reader
     def load_mapping(file)
       File.open(file, "r:BINARY") do |f|
         f.each do |l|
-          _m, single_byte, unicode = *l.match(/\A([0-9A-Za-z]+);([0-9A-F]{4})/)
-          @mapping["0x#{single_byte}".hex] = "0x#{unicode}".hex if single_byte
+          if l =~ /\A([0-9A-Za-z]+);([0-9A-F]{4})/
+            @mapping[$1.to_i(16)] = $2.to_i(16)
+          end
         end
       end
     end

--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -38,14 +38,15 @@ class PDF::Reader
       h[i] = CONTROL_CHARS.include?(i) ? UNKNOWN_CHAR : i
     }.freeze #: Hash[Integer, Integer]
 
+    # Cache mapping files to avoid re-reading and re-parsing the same file for
+    # every Encoding that uses it (e.g. many fonts sharing StandardEncoding).
+    FILE_MAPPINGS = {} #: Hash[String, Hash[Integer, Integer]]
+
     #: String
     attr_reader :unpack
 
     #: (Hash[Symbol, untyped] | Symbol | nil) -> void
     def initialize(enc)
-      # maps from character codes to Unicode codepoints
-      @mapping  = DEFAULT_MAPPING.dup #: Hash[Integer, Integer]
-
       # maps from character codes to UTF-8 strings.
       @string_cache  = {} #: Hash[Integer, String]
 
@@ -61,7 +62,15 @@ class PDF::Reader
       @differences = nil #: Hash[Integer, Integer] | nil
       @glyphlist = nil #: PDF::Reader::GlyphHash | nil
 
-      load_mapping(@map_file) if @map_file
+      # maps from character codes to Unicode codepoints
+      # If we have a mapping file, use the cached parsed version (loaded once per file)
+      if @map_file
+        @mapping = (
+          FILE_MAPPINGS[@map_file] ||= build_file_mapping(@map_file)
+        ).dup #: Hash[Integer, Integer]
+      else
+        @mapping = DEFAULT_MAPPING.dup
+      end #: Hash[Integer, Integer]
 
       if enc.is_a?(Hash) && enc[:Differences]
         self.differences = enc[:Differences]
@@ -218,15 +227,17 @@ class PDF::Reader
       @glyphlist ||= PDF::Reader::GlyphHash.new
     end
 
-    #: (String) -> void
-    def load_mapping(file)
+    #: (String) -> Hash[Integer, Integer]
+    def build_file_mapping(file)
+      mapping = DEFAULT_MAPPING.dup
       File.open(file, "r:BINARY") do |f|
         f.each do |l|
           if l =~ /\A([0-9A-Za-z]+);([0-9A-F]{4})/
-            @mapping[$1.to_i(16)] = $2.to_i(16)
+            mapping[$1.to_i(16)] = $2.to_i(16)
           end
         end
       end
+      mapping.freeze
     end
 
   end

--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -34,6 +34,9 @@ class PDF::Reader
     CONTROL_CHARS = [0,1,2,3,4,5,6,7,8,11,12,14,15,16,17,18,19,20,21,22,23,
                      24,25,26,27,28,29,30,31] #: Array[Integer]
     UNKNOWN_CHAR = 0x25AF #: Integer # ▯
+    DEFAULT_MAPPING = (0..255).each_with_object({}) { |i, h|
+      h[i] = CONTROL_CHARS.include?(i) ? UNKNOWN_CHAR : i
+    }.freeze #: Hash[Integer, Integer]
 
     #: String
     attr_reader :unpack
@@ -41,7 +44,7 @@ class PDF::Reader
     #: (Hash[Symbol, untyped] | Symbol | nil) -> void
     def initialize(enc)
       # maps from character codes to Unicode codepoints
-      @mapping  = default_mapping #: Hash[Integer, Integer]
+      @mapping  = DEFAULT_MAPPING.dup #: Hash[Integer, Integer]
 
       # maps from character codes to UTF-8 strings.
       @string_cache  = {} #: Hash[Integer, String]
@@ -149,20 +152,6 @@ class PDF::Reader
     private
 
     # returns a hash that:
-    # - maps control chars and nil to the unicode "unknown character"
-    # - leaves all other bytes <= 255 unchaged
-    #
-    # Each specific encoding will change this default as required for their glyphs
-    #: () -> Hash[Integer, Integer]
-    def default_mapping
-      all_bytes = (0..255).to_a
-      tuples = all_bytes.map {|i|
-        CONTROL_CHARS.include?(i) ? [i, UNKNOWN_CHAR] : [i,i]
-      }
-      mapping = Hash[tuples]
-      mapping
-    end
-
     #: (Integer) -> String
     def internal_int_to_utf8_string(glyph_code)
       ret = [

--- a/lib/pdf/reader/font.rb
+++ b/lib/pdf/reader/font.rb
@@ -294,13 +294,11 @@ class PDF::Reader
     def to_utf8_via_cmap(params, cmap)
       case params
       when Integer
-        [
-          cmap.decode(params)
-        ].flatten.pack("U*")
+        cmap.decode(params).pack("U*")
       when String
-        unpack_string_to_array_of_ints(params, encoding.unpack).map { |code_point|
+        unpack_string_to_array_of_ints(params, encoding.unpack).flat_map { |code_point|
           cmap.decode(code_point)
-        }.flatten.pack("U*")
+        }.pack("U*")
       when Array
         params.collect { |param| to_utf8_via_cmap(param, cmap) }.join("")
       end

--- a/lib/pdf/reader/font.rb
+++ b/lib/pdf/reader/font.rb
@@ -97,12 +97,21 @@ class PDF::Reader
       extract_descriptor(obj)
       extract_descendants(obj)
       @width_calc = build_width_calculator #: widthCalculator
+      @utf8_cache = {} #: Hash[Integer, String]
     end
 
     #: (Integer | String | Array[Integer | String]) -> String
     def to_utf8(params)
       if @tounicode
-        to_utf8_via_cmap(params, @tounicode)
+        if params.is_a?(Integer)
+          cached = @utf8_cache[params]
+          return cached unless cached.nil?
+          result = to_utf8_via_cmap(params, @tounicode)
+          @utf8_cache[params] = result
+          result
+        else
+          to_utf8_via_cmap(params, @tounicode)
+        end
       else
         to_utf8_via_encoding(params)
       end

--- a/lib/pdf/reader/page_layout.rb
+++ b/lib/pdf/reader/page_layout.rb
@@ -122,7 +122,7 @@ class PDF::Reader
 
     #: (untyped, untyped, untyped) -> untyped
     def local_string_insert(haystack, needle, index)
-      haystack[Range.new(index, index + needle.length - 1)] = String.new(needle)
+      haystack[index, needle.length] = needle
     end
 
     #: (untyped) -> untyped

--- a/lib/pdf/reader/page_state.rb
+++ b/lib/pdf/reader/page_state.rb
@@ -405,7 +405,10 @@ class PDF::Reader
           @text_matrix.c, @text_matrix.d,
           @text_matrix.e, @text_matrix.f
         )
-        @font_size = @text_rendering_matrix = nil # invalidate cached value
+        @text_rendering_matrix = nil # invalidate cached value
+        # we used to invalidate @font_size here too, but it's not required
+        # font_size depends only on trm.b/trm.d (scale/rotation), not trm.e/f (translation),
+        # so it remains valid after a glyph displacement and does not need invalidation
       end
 
       private

--- a/lib/pdf/reader/rectangle.rb
+++ b/lib/pdf/reader/rectangle.rb
@@ -70,10 +70,21 @@ module PDF
         bottom_right.x - bottom_left.x
       end
 
+      # Is the point inside this rectangle? Nicer to read and use than contains_xy?(), but
+      # allocates more objects so be careful using on hot code paths.
+      #
       #: (PDF::Reader::Point) -> bool
       def contains?(point)
-        point.x >= bottom_left.x && point.x <= top_right.x &&
-          point.y >= bottom_left.y && point.y <= top_right.y
+        contains_xy?(point.x, point.y)
+      end
+
+      # Is the point inside this rectangle? Worse to read and use than contains?(), but
+      # allocates fewer objects so may be preferrable on hot code paths.
+      #
+      #: (Numeric, Numeric) -> bool
+      def contains_xy?(x, y)
+        x >= bottom_left.x && x <= top_right.x &&
+          y >= bottom_left.y && y <= top_right.y
       end
 
       # A pdf-style 4-number array

--- a/lib/pdf/reader/text_run.rb
+++ b/lib/pdf/reader/text_run.rb
@@ -7,9 +7,6 @@ class PDF::Reader
   class TextRun
     include Comparable
 
-    #: PDF::Reader::Point
-    attr_reader :origin
-
     #: Numeric
     attr_reader :width
 
@@ -23,13 +20,21 @@ class PDF::Reader
 
     #: (Numeric, Numeric, Numeric, Numeric, String) -> void
     def initialize(x, y, width, font_size, text)
-      @origin = PDF::Reader::Point.new(x, y) #: PDF::Reader::Point
+      @x = x #: Numeric
+      @y = y #: Numeric
       @width = width
       @font_size = font_size
       @text = text
+      @origin = nil #: PDF::Reader::Point | nil
       @endx = nil #: Numeric | nil
       @endy = nil #: Numeric | nil
       @mergable_range = nil #: Range[Numeric] | nil
+    end
+
+    # Lazily constructed to avoid allocating a Point on every TextRun
+    #: () -> PDF::Reader::Point
+    def origin
+      @origin ||= PDF::Reader::Point.new(@x, @y)
     end
 
     # Allows collections of TextRun objects to be sorted. They will be sorted
@@ -53,22 +58,22 @@ class PDF::Reader
 
     #: () -> Numeric
     def x
-      @origin.x
+      @x
     end
 
     #: () -> Numeric
     def y
-      @origin.y
+      @y
     end
 
     #: () -> Numeric
     def endx
-      @endx ||= @origin.x + width
+      @endx ||= @x + width
     end
 
     #: () -> Numeric
     def endy
-      @endy ||= @origin.y + font_size
+      @endy ||= @y + font_size
     end
 
     #: () -> Numeric


### PR DESCRIPTION
A variety of tweaks to text extraction related code to allocate fewer objects. The difference is significant, the below benchmarks were run on MRI 3.4.9:

* `cairo-unicode.pdf`: 305k -> 182k allocations (~40% reduction)
* `pdflatex.pdf`: 731K -> 540K allocations (~26% reduction)
* `prince1.pdf`: 59k -> 36K allocations (~38% reduction)
 
## Before

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    18.956M memsize (     0.000  retained)
                       305.100k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.471M memsize (     1.018M retained)
                        65.684k objects (    13.994k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   373.871k memsize (     0.000  retained)
                         5.216k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   970.205k memsize (     0.000  retained)
                        14.009k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     5.160M memsize (     0.000  retained)
                        59.366k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    46.900M memsize (     0.000  retained)
                       731.675k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
````

## After

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------             
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    13.232M memsize (     7.488k retained)
                       182.729k objects (     2.000  retained)
                        50.000  strings (     1.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf   
         type1-arial     4.409M memsize (     1.026M retained)
                        64.387k objects (    13.996k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   284.903k memsize (     0.000  retained)
                         3.284k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   817.597k memsize (     0.000  retained)
                        10.011k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf 
             prince1     4.087M memsize (     7.488k retained)
                        36.455k objects (     2.000  retained)
                        50.000  strings (     1.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    42.946M memsize (     0.000  retained)
                       540.417k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```

