### PR TITLE
Intern operator Token objects to avoid one allocation per content-stream op

### DIFF
--- a/lib/pdf/reader/parser.rb
+++ b/lib/pdf/reader/parser.rb
@@ -34,6 +34,7 @@ class PDF::Reader
   class Parser
 
     TOKEN_STRATEGY = proc { |parser, token| Token.new(token) } #: Proc
+    INTERNED_TOKENS = {} #: Hash[String, PDF::Reader::Token]
 
     STRATEGIES = {
       "/"  => proc { |parser, token| parser.send(:pdf_name) },
@@ -104,7 +105,7 @@ class PDF::Reader
       elsif token.is_a? PDF::Reader::Reference
         token
       elsif @operators.has_key? token
-        Token.new(token)
+        INTERNED_TOKENS[token] ||= Token.new(token)
       elsif token.frozen?
         token
       elsif match?(token, /\d*\.\d/)


### PR DESCRIPTION
`parse_token` was calling `Token.new(token)` for every operator recognised in the operators hash. Since PDF content streams repeat a small fixed set of operators (Tj, BT, ET, cm, Td, …) many times, a class-level `INTERNED_TOKENS` hash now caches each unique Token after it is created the first time.

A small reduction in object allocations when run on MRI 3.4.9:

* `cairo-unicode.pdf`: 182k -> 179k allocations (~1% reduction)
* `pdflatex.pdf`: 540K -> 530K allocations (~1% reduction)
* `prince1.pdf`: 36k -> 34K allocations (~5% reduction)

## Before

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    13.240M memsize (     7.488k retained)
                       182.824k objects (     2.000  retained)
                        50.000  strings (     1.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.409M memsize (     1.026M retained)
                        64.388k objects (    13.996k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   285.063k memsize (     0.000  retained)
                         3.285k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   817.757k memsize (     0.000  retained)
                        10.012k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     4.088M memsize (     7.488k retained)
                        36.463k objects (     2.000  retained)
                        50.000  strings (     1.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    42.953M memsize (     0.000  retained)
                       540.457k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```

## After

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    13.093M memsize (    10.128k retained)
                       179.196k objects (    64.000  retained)
                        50.000  strings (    31.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.409M memsize (     1.026M retained)
                        64.383k objects (    13.998k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   284.383k memsize (     0.000  retained)
                         3.268k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   812.877k memsize (   480.000  retained)
                         9.890k objects (    12.000  retained)
                        50.000  strings (     6.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     3.998M memsize (     7.648k retained)
                        34.198k objects (     6.000  retained)
                        50.000  strings (     3.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    42.562M memsize (   160.000  retained)
                       530.697k objects (     4.000  retained)
                        50.000  strings (     2.000  retained)
```