### PR TITLE
Eliminate String allocation in Reference#hash via integer arithmetic

### DIFF
--- a/lib/pdf/reader/reference.rb
+++ b/lib/pdf/reader/reference.rb
@@ -71,7 +71,7 @@ class PDF::Reader
     # return an identical hash
     #: () -> Integer
     def hash
-      "#{self.id}:#{self.gen}".hash
+      (id << 16) ^ gen
     end
     ################################################################################
   end

--- a/spec/reader/reference_spec.rb
+++ b/spec/reader/reference_spec.rb
@@ -11,6 +11,19 @@ describe PDF::Reader::Reference do
       expect(one.hash).to eq(two.hash)
     end
 
+    it "returns a different hash for two objects with different IDs" do
+      one = PDF::Reader::Reference.new(1,0)
+      two = PDF::Reader::Reference.new(2,0)
+
+      expect(one.hash).to_not eq(two.hash)
+    end
+
+    it "returns a different hash for two objects with different generations" do
+      one = PDF::Reader::Reference.new(1,0)
+      two = PDF::Reader::Reference.new(1,1)
+
+      expect(one.hash).to_not eq(two.hash)
+    end
   end
 
   describe "#==" do


### PR DESCRIPTION
`"#{id}:#{gen}".hash` created a String on every Hash key lookup. Use `(id << 16) ^ gen` for a collision-resistant integer hash with zero allocations.

A small reduction in object allocations when run on MRI 3.4.9:

* `cairo-unicode.pdf`: 179k -> 174k allocations (~2% reduction)
* `pdflatex.pdf`: 530K -> 515K allocations (~2% reduction)
* `prince1.pdf`: 34k -> 33K allocations (~2% reduction)

## Before

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    13.093M memsize (    10.128k retained)
                       179.200k objects (    64.000  retained)
                        50.000  strings (    31.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.409M memsize (     1.026M retained)
                        64.387k objects (    13.998k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   284.543k memsize (     0.000  retained)
                         3.272k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   812.877k memsize (   480.000  retained)
                         9.890k objects (    12.000  retained)
                        50.000  strings (     6.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     3.999M memsize (     7.648k retained)
                        34.230k objects (     6.000  retained)
                        50.000  strings (     3.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    42.560M memsize (   160.000  retained)
                       530.637k objects (     4.000  retained)
                        50.000  strings (     2.000  retained)
```

## After

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    12.915M memsize (    10.128k retained)
                       174.743k objects (    64.000  retained)
                        50.000  strings (    31.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.407M memsize (     1.026M retained)
                        64.342k objects (    13.998k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   282.743k memsize (     0.000  retained)
                         3.227k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   807.037k memsize (   480.000  retained)
                         9.744k objects (    12.000  retained)
                        50.000  strings (     6.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     3.956M memsize (     7.648k retained)
                        33.150k objects (     6.000  retained)
                        50.000  strings (     3.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    41.972M memsize (   160.000  retained)
                       515.939k objects (     4.000  retained)
                        50.000  strings (     2.000  retained)
```