### PR TITLE
Eliminate TransformationMatrix allocation per glyph via prepend_translation!

### DIFF
--- a/lib/pdf/reader/page_state.rb
+++ b/lib/pdf/reader/page_state.rb
@@ -146,14 +146,7 @@ class PDF::Reader
       #####################################################
 
       def move_text_position(x, y) # Td
-        temp = TransformationMatrix.new(1, 0,
-                                        0, 1,
-                                        x, y)
-        @text_line_matrix = temp.multiply!(
-          @text_line_matrix.a, @text_line_matrix.b,
-          @text_line_matrix.c, @text_line_matrix.d,
-          @text_line_matrix.e, @text_line_matrix.f
-        )
+        @text_line_matrix.prepend_translation!(x, y)
         @text_matrix = @text_line_matrix.dup
         @font_size = @text_rendering_matrix = nil # invalidate cached value
       end
@@ -397,14 +390,7 @@ class PDF::Reader
         end
         # TODO: support ty > 0
         ty = 0
-        temp = TransformationMatrix.new(1, 0,
-                                        0, 1,
-                                        tx, ty)
-        @text_matrix = temp.multiply!(
-          @text_matrix.a, @text_matrix.b,
-          @text_matrix.c, @text_matrix.d,
-          @text_matrix.e, @text_matrix.f
-        )
+        @text_matrix.prepend_translation!(tx, ty)
         @text_rendering_matrix = nil # invalidate cached value
         # we used to invalidate @font_size here too, but it's not required
         # font_size depends only on trm.b/trm.d (scale/rotation), not trm.e/f (translation),

--- a/lib/pdf/reader/transformation_matrix.rb
+++ b/lib/pdf/reader/transformation_matrix.rb
@@ -54,6 +54,17 @@ class PDF::Reader
        @e,@f,1]
     end
 
+    # Apply a left-multiplication by a translation matrix [1, 0, 0, 1, tx, ty]
+    # without allocating a new TransformationMatrix.
+    #
+    #: (Numeric, Numeric) -> void
+    def prepend_translation!(tx, ty)
+      new_e = (tx * @a) + (ty * @c) + @e
+      new_f = (tx * @b) + (ty * @d) + @f
+      @e = new_e
+      @f = new_f
+    end
+
     # multiply this matrix with another.
     #
     # the second matrix is represented by the 6 scalar values that are changeable


### PR DESCRIPTION
`process_glyph_displacement` was allocating a new `TransformationMatrix` on every character painted. Adding `prepend_translation!`` allows in-place mutation

Also applied to `move_text_position` to save an allocation per text-position move.

A small reduction in object allocations when run on MRI 3.4.9:

* `cairo-unicode.pdf`: 174k -> 153k allocations (~12% reduction)
* `pdflatex.pdf`: 515K -> 433K allocations (~2% reduction)
* `prince1.pdf`: 33k -> 30K allocations (~15% reduction)

## Before

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    12.915M memsize (    10.128k retained)
                       174.743k objects (    64.000  retained)
                        50.000  strings (    31.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.407M memsize (     1.026M retained)
                        64.342k objects (    13.998k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   282.743k memsize (     0.000  retained)
                         3.227k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   807.037k memsize (   480.000  retained)
                         9.744k objects (    12.000  retained)
                        50.000  strings (     6.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     3.956M memsize (     7.648k retained)
                        33.150k objects (     6.000  retained)
                        50.000  strings (     3.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    41.972M memsize (   160.000  retained)
                       515.939k objects (     4.000  retained)
                        50.000  strings (     2.000  retained)
```

## After

```
$ ruby -I lib scripts/benchmark_allocations.rb 
Calculating -------------------------------------
/Users/jh/src/pdf-reader/scripts/../spec/data/cairo-unicode.pdf
       cairo-unicode    11.204M memsize (    10.128k retained)
                       153.359k objects (    64.000  retained)
                        50.000  strings (    31.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/type1-arial.pdf
         type1-arial     4.399M memsize (     1.026M retained)
                        64.243k objects (    13.998k retained)
                        50.000  strings (    50.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/truetype-arial.pdf
      truetype-arial   252.743k memsize (     0.000  retained)
                         2.852k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/ascii85_filter.pdf
      ascii85_filter   698.517k memsize (   480.000  retained)
                         8.383k objects (    12.000  retained)
                        50.000  strings (     6.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/prince1.pdf
             prince1     3.722M memsize (     7.648k retained)
                        30.233k objects (     6.000  retained)
                        50.000  strings (     3.000  retained)
/Users/jh/src/pdf-reader/scripts/../spec/data/pdflatex.pdf
            pdflatex    35.344M memsize (   160.000  retained)
                       433.088k objects (     4.000  retained)
                        50.000  strings (     2.000  retained)
```