### PR TITLE
Handle invalid Unicode code points in differences tables

### DIFF
--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -185,9 +185,20 @@ class PDF::Reader
 
     #: (String) -> String
     def convert_to_utf8(str)
-      ret = str.unpack(unpack).map! { |c| @mapping[c.to_i] || c }.pack("U*")
+      ret = str.unpack(unpack).map! { |c|
+        codepoint = @mapping[c.to_i] || c
+        valid_unicode_scalar?(codepoint) ? codepoint : UNKNOWN_CHAR
+      }.pack("U*")
       ret.force_encoding("UTF-8")
       ret
+    end
+
+    # true if the integer is a Unicode scalar value that can be encoded as
+    # UTF-8. Surrogates (U+D800..U+DFFF) and code points above U+10FFFF are
+    # excluded, as packing them produces invalid UTF-8 byte sequences.
+    #: (Integer) -> bool
+    def valid_unicode_scalar?(codepoint)
+      codepoint.between?(0, 0xD7FF) || codepoint.between?(0xE000, 0x10FFFF)
     end
 
     #: (Symbol) -> String

--- a/spec/encoding_spec.rb
+++ b/spec/encoding_spec.rb
@@ -68,6 +68,21 @@ describe PDF::Reader::Encoding do
       end
     end
 
+    context "when a differences table maps to a code point that isn't valid UTF-8" do
+      let!(:enc) do
+        # a glyph name like /L55473 resolves to code point 0xD8B1, a UTF-16
+        # surrogate that can't be encoded as UTF-8 on its own
+        PDF::Reader::Encoding.new(:Encoding    => :MacRomanEncoding,
+                                  :Differences => [2, :L55473]
+                                )
+      end
+      it "returns valid UTF-8 with the unknown char box" do
+        result = enc.to_utf8("\002")
+        expect(result.valid_encoding?).to eql(true)
+        expect(result).to eql("▯")
+      end
+    end
+
     context "when the encoding is Identity-H" do
       it "returns utf-8 squares" do
         e = PDF::Reader::Encoding.new("Identity-H")


### PR DESCRIPTION
Fixes #602.

Some PDFs have a differences table that maps a byte to a glyph name like `/L55473`, which resolves to code point 0xD8B1, a lone UTF-16 surrogate. Packing that into a String produces bytes that aren't valid UTF-8, so later calls such as `String#strip` in `PageLayout#interesting_rows` raise `ArgumentError: invalid byte sequence in UTF-8`.

`convert_to_utf8` now checks each code point and substitutes the existing unknown-char box (▯) for surrogates and values above U+10FFFF, matching how unmapped glyphs are already handled. Added a spec for a differences table that maps to a surrogate.