### PR TITLE
Avoid returning invalid utf8 from Encoding#to_utf8

### DIFF
--- a/lib/pdf/reader/encoding.rb
+++ b/lib/pdf/reader/encoding.rb
@@ -163,9 +163,13 @@ class PDF::Reader
     # returns a hash that:
     #: (Integer) -> String
     def internal_int_to_utf8_string(glyph_code)
-      ret = [
-        @mapping[glyph_code.to_i] || glyph_code.to_i
-      ].pack("U*")
+      codepoint = @mapping[glyph_code.to_i] || glyph_code.to_i
+      if valid_unicode_scalar?(codepoint.to_i)
+        codepoints = [codepoint]
+      else
+        codepoints = [UNKNOWN_CHAR]
+      end
+      ret = codepoints.pack("U*")
       ret.force_encoding("UTF-8")
       ret
     end

--- a/spec/data/difference_table_with_unmatched_utf16_surrogate.pdf
+++ b/spec/data/difference_table_with_unmatched_utf16_surrogate.pdf
@@ -1,0 +1,98 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Pages 3 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<< /Count 1
+/Kids [5 0 R]
+/Type /Pages
+>>
+endobj
+4 0 obj
+<< /Length 220
+>>
+stream
+q
+
+BT
+36.0 748.452 Td
+/F1.0 12 Tf
+<546869732066696c6520686173206120756e6d617463686564205554462d313620737572726f6761746520696e206120646966666572656e6365207461626c65> Tj
+ET
+
+
+BT
+36.0 734.724 Td
+/F2.0 12 Tf
+[<02>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /ArtBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/Contents 4 0 R
+/CropBox [0 0 612 792]
+/MediaBox [0 0 612 792]
+/Parent 3 0 R
+/Resources << /Font << /F1.0 6 0 R
+/F2.0 8 0 R
+>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+/TrimBox [0 0 612 792]
+/Type /Page
+>>
+endobj
+6 0 obj
+<< /BaseFont /Courier
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+7 0 obj
+<< /BaseEncoding /WinAnsiEncoding
+/Differences [2 /L55473 /L55474]
+/Type /Encoding
+>>
+endobj
+8 0 obj
+<< /BaseFont /Helvetica
+/Encoding 7 0 R
+/FirstChar 2
+/Subtype /Type1
+/Type /Font
+/Widths [500 500]
+>>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000486 00000 n 
+0000000764 00000 n 
+0000000859 00000 n 
+0000000960 00000 n 
+trailer
+<< /Info 1 0 R
+/Root 2 0 R
+/Size 9
+>>
+startxref
+1077
+%%EOF

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1879,4 +1879,16 @@ describe PDF::Reader, "integration specs" do
       end
     end
   end
+
+  context "PDF with a difference table that maps to an unmatched utf16 surrogate" do
+    let(:filename) { pdf_spec_file("difference_table_with_unmatched_utf16_surrogate") }
+
+    it "extracts text correctly, replacing the invalid glyph with a placeholder" do
+      PDF::Reader.open(filename) do |reader|
+        text = reader.pages.first.text
+        expect(text).to include("This file has")
+        expect(text).to include("▯")
+      end
+    end
+  end
 end

--- a/spec/integrity.yml
+++ b/spec/integrity.yml
@@ -74,6 +74,9 @@ data/difference_table2.pdf:
 data/difference_table_encrypted.pdf:
   :bytes: 1442
   :md5: 142596eae43ecd6bad12ccfd3d0921d1
+data/difference_table_with_unmatched_utf16_surrogate.pdf:
+  :bytes: 1333
+  :md5: d5923a8eda5f1e97b57f0603782a28d9
 data/distiller_unicode.pdf:
   :bytes: 273800
   :md5: a3c22cb58416c789dcc6dc60a1270209


### PR DESCRIPTION
In some rare situations, Encoding#to_utf8 was returning invalid utf8 strings. That's not the goal, pdf-reader should always return valid utf8 when it claims to. The problem is that we can't always trust the difference tables pdf producing apps provide. In this particular case, we can't blindly take their difference values if they're an unmatched UTF-16 surrogate pair.

This was partially fixed in #604, but adding the integration spec exposed that a further fix was required.

I don't love the style here, but the test is green so I'll commit it. I can tidy the code later.

Fixes #602 