### PR TITLE
Accept any IO-like object that responds to read and seek

### DIFF
--- a/lib/pdf/reader/object_hash.rb
+++ b/lib/pdf/reader/object_hash.rb
@@ -59,9 +59,9 @@ class PDF::Reader
     #
     #   :password - the user password to decrypt the source PDF
     #
-    #: ((IO | Tempfile | StringIO | String), ?Hash[Symbol, untyped]) -> void
+    #: (untyped, ?Hash[Symbol, untyped]) -> void
     def initialize(input, opts = {})
-      @io          = extract_io_from(input) #: IO | Tempfile | StringIO
+      @io          = extract_io_from(input) #: untyped
       @xref        = PDF::Reader::XRef.new(@io) #: PDF::Reader::XRef[PDF::Reader::Reference]
       @pdf_version = read_version #: Float
       @trailer     = @xref.trailer #: Hash[Symbol, untyped]
@@ -708,9 +708,9 @@ class PDF::Reader
       version.to_f
     end
 
-    #: (IO | Tempfile | StringIO | String) -> (IO | Tempfile | StringIO)
+    #: (untyped) -> untyped
     def extract_io_from(input)
-      if input.is_a?(IO) || input.is_a?(StringIO) || input.is_a?(Tempfile)
+      if input.respond_to?(:read) && input.respond_to?(:seek)
         input
       elsif File.file?(input.to_s)
         StringIO.new read_as_binary(input.to_s)

--- a/spec/reader/object_hash_spec.rb
+++ b/spec/reader/object_hash_spec.rb
@@ -1,6 +1,8 @@
 # typed: false
 # coding: utf-8
 
+require "delegate"
+
 describe PDF::Reader::ObjectHash do
   describe "mixins" do
     it "has enumerable mixed in" do
@@ -35,6 +37,18 @@ describe PDF::Reader::ObjectHash do
         tempfile.write binread(filename)
         tempfile.rewind
         h = PDF::Reader::ObjectHash.new(tempfile)
+
+        expect(h.map { |ref, obj| obj.class }.size).to eql(57)
+      end
+    end
+
+    # Wrappers that delegate to an IO (chunked-download objects, decorators)
+    # quack like an IO without inheriting from it
+    it "correctly loads a PDF via an IO-like object that delegates read and seek" do
+      filename = pdf_spec_file("cairo-unicode")
+
+      File.open(filename, "rb") do |file|
+        h = PDF::Reader::ObjectHash.new(SimpleDelegator.new(file))
 
         expect(h.map { |ref, obj| obj.class }.size).to eql(57)
       end


### PR DESCRIPTION
The `ArgumentError` message and the `ObjectHash.new` docs have always promised "an IO-like object", but `extract_io_from` checks three concrete classes — and the list has had to grow one class at a time (`Tempfile` was added in #498). Meanwhile, real-world IO-like objects keep hitting the raise: chunked download wrappers (#501), and delegating decorators around SFTP streams (our case — a pipeline file object that forwards `read`/`seek` to the IO it wraps).

This PR ducks the check: anything responding to `read` and `seek` is accepted as-is. Backward compatible by construction — `IO`, `StringIO` and `Tempfile` all respond to both, and strings still route to the filename branch (`Pathname` responds to `read` but not `seek`, so it keeps loading from disk as before).

Honest scope note: the reader needs random access, so this deliberately still requires `seek` — forward-only streams like `Zip::InputStream` (#520) remain unsupported and would need buffering first.

The inline RBS signatures for the ducked input are updated to `untyped`; happy to type it against an interface instead if you'd prefer.

Spec added alongside the Tempfile one from #498, using a `SimpleDelegator` fixture. Full suite green (2264 examples), `cane` at its existing baseline.
